### PR TITLE
LDAP: Add support for URI schemes other than LDAP.

### DIFF
--- a/README.LDAP
+++ b/README.LDAP
@@ -66,9 +66,15 @@ LDAPDefaultGID 100
 Well... the keywords should be self-explanatory, but here we go for some
 details anyway:
 
+- LDAPScheme is the scheme (aka protocol) to connect with to the LDAP server.
+It defaults to 'ldap'. To connect to a server listening on TLS port, set it
+to 'ldaps' (and change the port below).
+
 - LDAPServer is the LDAP server name (hey!) . It defaults to 'localhost'.
 
-- LDAPPort is the connecton port. It defaults to 389, the standard port.
+- LDAPPort is the connection port. It defaults to 389, the standard port.
+Port value should be changed for 'ldaps' connection (the TLS port for an
+LDAP server is usually 636).
 
 - LDAPBaseDN is the search starting point for users accounts. Your tree must
 have posixAccount objects under that node.
@@ -95,7 +101,8 @@ default) .
 needed with OpenLDAP servers. It is the default.
 
 - LDAPUseTLS can be True or False. True means that the server should use TLS
-to connect to the LDAP server.
+to connect to the LDAP server over ldap protocol. This property has no effect
+when ldaps protocol is used, as the connection is inherently secured with TLS.
 
 - LDAPAuthMethod can be BIND (experimental, but default if there is no
 LDAPBindDN) or PASSWORD (default if a LDAPBindDN is set). The former tries

--- a/pureftpd-ldap.conf
+++ b/pureftpd-ldap.conf
@@ -7,6 +7,13 @@
 #############################################
 
 
+# Optional : scheme to connect with to LDAP server. Default: ldap
+# Other possible values: ldaps, ldapi, etc.
+# Remember to set LDAPPort accordingly.
+
+LDAPScheme ldap
+
+
 # Optional : name of the LDAP server. Default : localhost
 
 LDAPServer ldap.example.com
@@ -64,6 +71,7 @@ LDAPBindPW r00tPaSsw0rD
 
 
 # Optional: use TLS to connect to the LDAP server
+# Note: if ldaps scheme is used, this property has no effect
 # LDAPUseTLS  True
 
 

--- a/src/log_ldap.h
+++ b/src/log_ldap.h
@@ -35,10 +35,16 @@
 #define PASSWD_LDAP_SMD5_PREFIX "{smd5}"
 #define PASSWD_LDAP_SHA_PREFIX "{sha}"
 #define PASSWD_LDAP_SSHA_PREFIX "{ssha}"
+#define LDAP_DEFAULT_SCHEME "ldap"
 #define LDAP_DEFAULT_SERVER "localhost"
 #define LDAP_DEFAULT_PORT 389
 #define LDAP_DEFAULT_FILTER "(&(objectClass=posixAccount)(uid=\\L))"
 #define LDAP_DEFAULT_VERSION 3
+
+/* RFC 3986 - http://tools.ietf.org/html/rfc3986 */
+#define URI_SCHEME_SEPARATOR ":"
+#define URI_AUTHORITY_LEADER "//"
+#define URI_PORT_LEADER ":"
 
 void pw_ldap_parse(const char * const file);
 

--- a/src/log_ldap_p.h
+++ b/src/log_ldap_p.h
@@ -9,6 +9,8 @@
 #include <lber.h>
 #include <ldap.h>
 
+static char *ldap_uri;
+static char *ldap_scheme;
 static char *ldap_host;
 static char *port_s;
 static int port;
@@ -30,6 +32,7 @@ static int use_ldap_bind_method;
 static char *ldap_default_home_directory;
 
 static ConfigKeywords ldap_config_keywords[] = {
+    { "LDAPScheme", &ldap_scheme },
     { "LDAPServer", &ldap_host },
     { "LDAPPort", &port_s },    
     { "LDAPBindDN", &binddn },        


### PR DESCRIPTION
Hi,

This pull request answers the issue "Add support for LDAPS auth. by using ldap_initialize() instead of ldap_init()" filed by Farzy.

Note that, by default, the LDAP URI is not built with asprintf function which seems not to be available on all platforms. I welcome suggestions on the implementation of the switch... :)
