### PR TITLE
extended the pgsql auth module with salts

### DIFF
--- a/README.PGSQL
+++ b/README.PGSQL
@@ -52,7 +52,9 @@ PGSQLUser       root
 PGSQLPassword   rootpw
 PGSQLDatabase   pureftpd
 PGSQLCrypt      cleartext
+PGSQLSalting    append
 PGSQLGetPW      SELECT "Password" FROM "users" WHERE "User"='\L'
+PGSQLGetSalt    SELECT "Salt" FROM "users" WHERE "User"='\L'
 PGSQLGetUID     SELECT "Uid" FROM "users" WHERE "User"='\L'
 PGSQLGetGID     SELECT "Gid" FROM "users" WHERE "User"='\L'
 PGSQLGetDir     SELECT "Dir" FROM "users" WHERE "User"='\L'

--- a/pureftpd-pgsql.conf
+++ b/pureftpd-pgsql.conf
@@ -28,6 +28,10 @@ PGSQLDatabase   pureftpd
 # Valid values are : "cleartext", "crypt", "md5", "sha1" and "any"
 PGSQLCrypt      cleartext
 
+# Mandatory : how salts should be applied to passwords before encryption
+# Valid values are : "append", "prepend" and "none"
+PGSQLSalting    append
+
 # In the following directives, parts of the strings are replaced at
 # run-time before performing queries :
 #
@@ -43,12 +47,15 @@ PGSQLCrypt      cleartext
 
 # Query to execute in order to fetch the password
 
-PGSQLGetPW      SELECT Password FROM users WHERE User='\L'
+PGSQLGetPW      SELECT "Password" FROM "users" WHERE "User"='\L'
 
+# Query to execute in order to fetch the salt. This is mandatory if Salting is set to append or prepend.
+
+PGSQLGetSalt		SELECT "Salt" FROM "users" WHERE "User"='\L'
 
 # Query to execute in order to fetch the system user name or uid
 
-PGSQLGetUID     SELECT Uid FROM users WHERE User='\L'
+PGSQLGetUID     SELECT "Uid" FROM "users" WHERE "User"='\L'
 
 
 # Optional : default UID - if set this overrides PGSQLGetUID
@@ -58,7 +65,7 @@ PGSQLGetUID     SELECT Uid FROM users WHERE User='\L'
 
 # Query to execute in order to fetch the system user group or gid
 
-PGSQLGetGID     SELECT Gid FROM users WHERE User='\L'
+PGSQLGetGID     SELECT "Gid" FROM "users" WHERE "User"='\L'
 
 
 # Optional : default GID - if set this overrides PGSQLGetGID
@@ -68,31 +75,31 @@ PGSQLGetGID     SELECT Gid FROM users WHERE User='\L'
 
 # Query to execute in order to fetch the home directory
 
-PGSQLGetDir     SELECT Dir FROM users WHERE User='\L'
+PGSQLGetDir     SELECT "Dir" FROM "users" WHERE "User"='\L'
 
 
 # Optional : query to get the maximal number of files 
 # Pure-FTPd must have been compiled with virtual quotas support.
 
-# PGSQLGetQTAFS  SELECT QuotaFiles FROM users WHERE User='\L'
+# PGSQLGetQTAFS  SELECT "QuotaFiles" FROM "users" WHERE "User"='\L'
 
 
 # Optional : query to get the maximal disk usage (virtual quotas)
 # The number should be in Megabytes.
 # Pure-FTPd must have been compiled with virtual quotas support.
 
-# PGSQLGetQTASZ  SELECT QuotaSize FROM users WHERE User='\L'
+# PGSQLGetQTASZ  SELECT "QuotaSize" FROM "users" WHERE "User"='\L'
 
 
 # Optional : ratios. The server has to be compiled with ratio support.
 
-# PGSQLGetRatioUL SELECT ULRatio FROM users WHERE User='\L'
-# PGSQLGetRatioDL SELECT DLRatio FROM users WHERE User='\L'
+# PGSQLGetRatioUL SELECT "ULRatio" FROM "users" WHERE "User"='\L'
+# PGSQLGetRatioDL SELECT "DLRatio" FROM "users" WHERE "User"='\L'
 
 
 # Optional : bandwidth throttling.
 # The server has to be compiled with throttling support.
 # Values are in KB/s .
 
-# PGSQLGetBandwidthUL SELECT ULBandwidth FROM users WHERE User='\L'
-# PGSQLGetBandwidthDL SELECT DLBandwidth FROM users WHERE User='\L'
+# PGSQLGetBandwidthUL SELECT "ULBandwidth" FROM "users" WHERE "User"='\L'
+# PGSQLGetBandwidthDL SELECT "DLBandwidth" FROM "users" WHERE "User"='\L'

--- a/src/log_pgsql.c
+++ b/src/log_pgsql.c
@@ -670,12 +670,15 @@ void pw_pgsql_check(AuthResult * const result,
     }
     free((void *) spwd);
     free((void *) salt);
-    /* Clear salted_password from memory, paranoia */        
-    volatile char *salted_password_ = (volatile char *) salted_password;
-    while (*salted_password_ != 0) {
-        *salted_password_++ = 0;
+    /* Clear salted_password from memory, paranoia */
+    if(strcasecmp(salting, SALT_SQL_NONE) != 0) {
+        /* but only IF we allocated space for it.. */
+        volatile char *salted_password_ = (volatile char *) salted_password;
+        while (*salted_password_ != 0) {
+            *salted_password_++ = 0;
+        }
+        free((void *) salted_password);
     }
-    free((void *) salted_password);
     if (uid != sql_default_uid) {
         free((void *) uid);
     }

--- a/src/log_pgsql.h
+++ b/src/log_pgsql.h
@@ -7,6 +7,9 @@
 #define PASSWD_SQL_MD5 "md5"
 #define PASSWD_SQL_SHA1 "sha1"
 #define PASSWD_SQL_ANY "any"
+#define SALT_SQL_APPEND "append"
+#define SALT_SQL_PREPEND "prepend"
+#define SALT_SQL_NONE "none"
 #define PGSQL_DEFAULT_SERVER "localhost"
 #define PGSQL_DEFAULT_PORT 5432
 #define PGSQL_MAX_REQUEST_LENGTH ((size_t) 8192U)

--- a/src/log_pgsql_p.h
+++ b/src/log_pgsql_p.h
@@ -10,7 +10,9 @@ static char *user;
 static char *pw;
 static char *db;
 static char *crypto;
+static char *salting;
 static char *sqlreq_getpw;
+static char *sqlreq_getsalt;
 static char *sqlreq_getuid;
 static char *sqlreq_getgid;
 static char *sqlreq_getdir;
@@ -37,7 +39,9 @@ static ConfigKeywords pgsql_config_keywords[] = {
     { "PGSQLPassword", &pw },
     { "PGSQLDatabase", &db },    
     { "PGSQLCrypt", &crypto },
+    { "PGSQLSalting", &salting },
     { "PGSQLGetPW", &sqlreq_getpw },
+    { "PGSQLGetSalt", &sqlreq_getsalt },
     { "PGSQLGetUID", &sqlreq_getuid },
     { "PGSQLDefaultUID", &sql_default_uid },
     { "PGSQLGetGID", &sqlreq_getgid },

--- a/src/messages_en.h
+++ b/src/messages_en.h
@@ -227,3 +227,4 @@
 #define MSG_PROT_BEFORE_PBSZ "PROT must be preceded by a successful PBSZ command"
 #define MSG_WARN_LDAP_USERPASS_EMPTY "LDAP returned no userPassword attribute, check LDAP access rights."
 #define MSG_LDAP_INVALID_AUTH_METHOD "Invalid LDAPAuthMethod in the configuration file. Should be 'bind' or 'password'."
+#define MSG_INVALID_SALTING_METHOD "Salting method in Config File is invalid. Method is: %s."


### PR DESCRIPTION
I was using your awesome slim pure-ftpd as a ftp server when I had to authenticate users via postgresql. Unfortunately the passwords stored in my database were salted and there was no way to tell the pgsql auth module about these salts.
Well now there is. :)