### PR TITLE
add options to pureftpd-ldap.conf to allow overriding LDAP uid/gid value...

### DIFF
--- a/README.LDAP
+++ b/README.LDAP
@@ -60,8 +60,9 @@ LDAPBaseDN cn=Users,dc=c9x,dc=org
 LDAPBindDN cn=Manager,dc=c9x,dc=org
 LDAPBindPW r00tPaSsw0rD
 LDAPDefaultUID 500
+LDAPForceDefaultUID False
 LDAPDefaultGID 100
-
+LDAPForceDefaultGID False
 
 Well... the keywords should be self-explanatory, but here we go for some
 details anyway:
@@ -89,6 +90,18 @@ LDAPBindDN/LDAPBindPW.
 
 - LDAPDefaultUID and LDAPDefaultGID are default values for objects without
 any entry for them.
+
+- LDAPForceDefaultUID and LDAPForceDefaultGID - These options both default to
+`False`. Any value other than `True` (case insensitive) is also treated as
+`False`.  When set these options cause the respective uid or gid value returned
+by the LDAP server for a username to be ignored and instead use the value set
+by `LDAPDefaultUID` or `LDAPDefaultGID`.  If the appropriate `LDAPDefaultXID`
+option is not set, these options have no effect.
+
+This is useful for allowing users to authenticate against LDAP but access or
+create content with common a set of ownership/permissions.  It also provides a
+measure of security in that it prevents pure-ftpd processes from being created
+with arbitrary uid/gids that may conflict with local accounts.
 
 - LDAPFilter is the filter to use in order to find the object to authenticate
 against. The special sequence \L is replaced with the login of the user. The

--- a/src/log_ldap_p.h
+++ b/src/log_ldap_p.h
@@ -22,9 +22,13 @@ static char *ldap_homedirectory;
 static char *ldap_version_s;
 static int ldap_version;
 static char *default_uid_s;
-static uid_t default_uid;
+static char *force_default_uid_s;
+static int force_default_uid = 0;
+static uid_t default_uid = 0;
 static char *default_gid_s;
-static gid_t default_gid;
+static char *force_default_gid_s;
+static int force_default_gid = 0;
+static gid_t default_gid = 0;
 static char *use_tls_s;
 static int use_tls;
 static char *ldap_auth_method_s;
@@ -42,7 +46,9 @@ static ConfigKeywords ldap_config_keywords[] = {
     { "LDAPHomeDir", &ldap_homedirectory },
     { "LDAPVersion", &ldap_version_s },
     { "LDAPDefaultUID", &default_uid_s },
+    { "LDAPForceDefaultUID", &force_default_uid_s },
     { "LDAPDefaultGID", &default_gid_s },
+    { "LDAPForceDefaultGID", &force_default_gid_s },
     { "LDAPUseTLS", &use_tls_s },
     { "LDAPAuthMethod", &ldap_auth_method_s },
     { "LDAPDefaultHomeDirectory", &ldap_default_home_directory },


### PR DESCRIPTION
...s

This patch adds to two options to pureftpd-ldap.conf:

```
LDAPForceDefaultUID True
LDAPForceDefaultGID True
```

These options both default to `False`. Any value other than `True` (case
insensitve) is also treated as `False`.  When set these options cause the
respective uid or gid value returned by the LDAP server for a username to be
ignored and instead use the value set by `LDAPDefaultUID` or `LDAPDefaultGID`.
If the appropriate `LDAPDefaultXID` option is not set, these options have no
effect.

An example complete configuration snippet:

```
LDAPDefaultUID 777
LDAPForceDefaultUID True
LDAPDefaultGID 888
LDAPForceDefaultGID True
```
