### PR TITLE
Fix building in case of HAVE_EXPLICIT_BZERO

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -25,8 +25,8 @@ void pure_memzero(void * const pnt, const size_t len)
     while (i < len) {
         pnt_[i++] = 0U;
     }
-}
 # endif
+}
 
 int pure_memcmp(const void * const b1_, const void * const b2_, size_t len)
 {


### PR DESCRIPTION
Currently if toolchain has implementation of explicit_bzero() and so
HAVE_EXPLICIT_BZERO gets defined during configuration compilation will
fail that way:
------------------------------------>8------------------------------
utils.c: In function 'pure_memzero':
utils.c:49:1: error: expected declaration or statement at end of input
 }
 ^
------------------------------------>8------------------------------

That happens because closing "#endif" is put 1 line below than really
meant.

Signed-off-by: Alexey Brodkin <abrodkin@synopsys.com>