### PR TITLE
[altlog] alllow symlinks

### DIFF
--- a/src/altlog.c
+++ b/src/altlog.c
@@ -36,9 +36,6 @@ static int altlog_write(const char *str)
 # ifdef ESPIPE
         && errno != ESPIPE
 # endif
-# ifdef EBADF
-        && errno != EBADF
-# endif
         ) {
         return -1;
     }

--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -5054,7 +5054,7 @@ static void doit(void)
             }
         } else {
             altlog_fd = open(altlog_filename,
-                             O_CREAT | O_WRONLY | O_NOFOLLOW, (mode_t) 0600);
+                             O_CREAT | O_WRONLY, (mode_t) 0600);
         }
         if (altlog_fd == -1) {
             logfile(LOG_ERR, "altlog %s: %s", altlog_filename, strerror(errno));


### PR DESCRIPTION
Follow-up from #40.

I've left the w3c format untouched as it seems tricky to handle due to the header requirement, what do you think?
