### PR TITLE
Allow chaining of chroot for homedir of virtual user

### DIFF
--- a/man/pure-ftpd.8.in
+++ b/man/pure-ftpd.8.in
@@ -595,7 +595,7 @@ allows remote users to log in as root if the password is known and \-u
 not used.
 
 .SH "UNUSUAL FEATURES"
-If a user's home directory is \fB/path/to/home/./\fR, FTP sessions under that UID will be chroot()ed. In addition, if a users's home directory is \fB/path/to/home/./directory\fR the session will be chroot()ed to /path/to/home and the FTP session will start in 'directory'.
+If a user's home directory is \fB/path/to/home/./\fR, FTP sessions under that UID will be chroot()ed. In addition, if a users's home directory is \fB/path/to/home/./directory\fR the session will be chroot()ed to /path/to/home and the FTP session will start in 'directory'. Multiple \fB/./\fR result in chained chroot()s.
 .PP
 As noted above, this
 .B pure\-ftpd

--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -1800,11 +1800,15 @@ void dopass(char *password)
         if (create_home_and_chdir(root_directory)) {
             die(421, LOG_ERR, MSG_NO_HOMEDIR);
         }
-        *++hd = 0;
-        hd++;
-        if (chroot(root_directory) || chdir(hd)) {
-            die(421, LOG_ERR, MSG_NO_HOMEDIR);
-        }
+        do {
+            *++hd = 0;
+            hd++;
+            if (chdir(root_directory) || chroot(root_directory) || chdir(hd)) {
+                die(421, LOG_ERR, MSG_NO_HOMEDIR);
+            }
+            root_directory = hd;
+            hd = strstr(root_directory, "/./");
+        } while (hd);
         chrooted = 1;
 #ifdef RATIOS
         if (ratio_for_non_anon == 0) {


### PR DESCRIPTION
Chaining of chroot is useful when parts of the homedir are supplied by untrusted users or untrusted users can possibly create symlinks in the path to homedir.
    
Each point in the chroot chain allows locking the user into a certain directory while further steps allow additional restrictions without possibility to widen the access by .. components or symlinks in the homedir value.

This is especially useful if a set of users should be restricted to `/home/someuser/` but someuser may hand out further restricted virtual users that may only access e.g. `/home/someuser/project1`. Just using the `/home/someuser/project1/./` would be dangerous, if the user can create a symlink in /home/someuser/project1 that points outside of its home as the chroot()ing is done as root without restricting the user to its home directory.

With this patch `/home/someuser/./project1/./` would be safe, because the symlink is only evaluated in an chroot that already restricts access to `/home/someuser/`. This also helps to avoid path canonicalization errors.