### PR TITLE
spelling fixes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -151,7 +151,7 @@ Credits for Pure-FTPd are going to the following ones.
 
 * Roger Constantin Demetrescu <roger.demetrescu <at> gmail.com>
 
-    Brazilian Portugese translation.
+    Brazilian Portuguese translation.
 
 * Freeman <freeman <at> ozac.org> :
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -200,7 +200,7 @@ old LIST and NLIST commands). Reported by Mime Cuvalo.
  - Properly handle custom paths in man pages. Thanks to Scott Haneda and
 Mathieu Parisot.
  - Have $localstatedir default to /var as it used to be unless
---localstatedir=... is explicitely passed to ./configure
+--localstatedir=... is explicitly passed to ./configure
  - Use @VERSION@ in man pages.
  - --without-pam disables PAM on OSX and iPhone.
  - Allow cross-compilation.
@@ -379,7 +379,7 @@ the right pid.
 can disable it.
     Correctly format %c and %% in fakesprintf().
     The connection socket is now created with the Nagle algorithm disabled.
-It was the trick to dramatically improve performance when transfering a lot
+It was the trick to dramatically improve performance when transferring a lot
 of small files.
     Updated getopt_long() and realpath() substitutes.
     Allow logging to named pipes (thanks to Steve Marple).
@@ -393,7 +393,7 @@ when a host is not found.
     The BSD getopt() update has been partly reverted.
 
 * Version 1.0.19:
-    Until OpenBSD has UBC, we need to explicitely call msync() to
+    Until OpenBSD has UBC, we need to explicitly call msync() to
 synchronize data written by mmap() and read by read().
     Real disk space is no more shown unless SHOW_REAL_DISK_SPACE is defined.
     Fygul's email address has changed.
@@ -415,7 +415,7 @@ because of a missing 'echo end' statement. Thanks to Peter Ahlert
     Max CPU time was bumped to 60 min.
     Disable hash_password() function call on MySQL 4.1.x and later.
     We now use two listening sockets (listenfd / listenfd6), one for IPv4, one
-for IPv6. The standalone_server() function has been reworked and splitted.
+for IPv6. The standalone_server() function has been reworked and split.
     New urlencode() function to escape characters in W3C and CLF altlog files.
 Based upon a suggestion and a patch by Volodin D.
     The xferlog format was also implemented by the way.
@@ -442,7 +442,7 @@ safe_fd_isset() and ignores descriptor -1 and it has been placed on the same
 places.
 
 * Version 1.0.17:
-    Some fixes were made to the traditionnal Chinese translation by Flaw Zero
+    Some fixes were made to the traditional Chinese translation by Flaw Zero
 <flawzero at eyou.com>.
     Autoconf was upgraded to 2.58.
     TLS_CERTIFICATE_PATH has been renamed TLS_CERTIFICATE_FILE.
@@ -539,7 +539,7 @@ readable. It fixes pure-uploadscript on some platforms like MacOS X.
 place of -y.
     MacOS X Panther has a lousy getnameinfo() implementation that doesn't fill
 the buffer when no DNS entry is found for a host and a numerical result wasn't
-explicitely asked. As a result, Pure-FTPd didn't even start on Panther (saying
+explicitly asked. As a result, Pure-FTPd didn't even start on Panther (saying
 "bad IP address") . We now check for EAI_NONAME if available and we retry with
 NI_NUMERICHOST if this is what getnameinfo() returns. Thanks to Yann Bizeul
 for his valuable help on this issue.
@@ -561,12 +561,12 @@ linker bugs (grrr...) .
 is a reserved keyword that needs quotes. Thanks to Henrik Edlund
 <henrik at edlund.org> .
     The maximal length of an account has been bumped a bit (42 chars),
-and that size is now consistent accross functions through the
+and that size is now consistent across functions through the
 MAX_USER_LENGTH macro. Thanks to Darth Vader (freddyke) for suggesting
 this.
     The comment about the location of the config file in the RedHat
 init script was synced with the new location.
-    Tokens in the configuration file are now case independant.
+    Tokens in the configuration file are now case independent.
     Automatic creation of home directories was fixed. Thanks to 
 Anthony DeRobertis for the fix.
     A typo in quota handling was fixed.
@@ -624,7 +624,7 @@ choke when the descriptor is -1. It fixes bus errors on FreeBSD.
 Passive IP addresses are now resolved in doit() for every new
 connection, by popular request. It means that "-P ftp.example.com" now
 works, even for dynamic addresses.
-    Split the funtion that creates an active data socket into two
+    Split the function that creates an active data socket into two
 parts : doport2() and doport3(). doport3() actually creates it,
 doport2() does other gadgets like checking for FXP, etc.
     Carefully check whether we have OpenBSD/MicroBSD-like MD5/SHA1
@@ -749,7 +749,7 @@ with the extauth module :)
 sysconf() . PAGE_SIZE and MAP_SIZE have become page_size and map_size.
 Thanks to brad at openbsd.org .
     Dutch translation updated - Johan Huisman <sietze.jan.huisman at 12move.nl>
-    Typo in log_extauth.h (bandwith -> bandwidth) . Fixes throttling with
+    Typo in log_extauth.h (bandwidth -> bandwidth) . Fixes throttling with
 extauth. Reported by iTooo <itooo at itooo.com> .
     Italian translation updates (Alex Dupre) .
     Workaround against Solaris streams bugs - Kenneth Stailey.
@@ -780,7 +780,7 @@ recursivity (makes Solaris happy) and faster processing.
     Use addreply_noformat() whenever possible (speedup).
     New switch : -Z (--customerproof) . Right now, it adds | 0600 or | 0700
 to chmod commands to avoid users locking their own files. Additionnaly, we
-now try a traditionnal chmod() call if fchmod() fails. There's a race here,
+now try a traditional chmod() call if fchmod() fails. There's a race here,
 but no security trouble to fear. Reported by Mark Reidel <mr at domainfactory.de>
     Spec file fixes, contributed by Jose Pedro Oliveira <jpo at di.uminho.pt>
     PureDB binary search could fail with -1 as a slot number - fixed.
@@ -894,7 +894,7 @@ Stailey <kstailey at yahoo.com> .
     Add a fake chroot wrapper for stat[v]fs[64]() and rm/mkdir.
     Check directory, not file for stat[v]fs[64]() - Option -k should really
 work now.
-    Dont count .ftpquota in pure-quotacheck. Reported by Jan Pavlik.
+    Don't count .ftpquota in pure-quotacheck. Reported by Jan Pavlik.
 
 * Version 1.0.6 :
     New fakechroot.{c,h} files. They contain wrappers for most I/O functions
@@ -1055,7 +1055,7 @@ any OS tweaking, it's simpler code, etc.
     -H is now a synonym for -n in pure-ftpwho.
     Use safe_write() when possible instead of plain write().
     Much efficient buffering code in ls.c .
-    New -m switch in pure-pw. New environement variables for the default path.
+    New -m switch in pure-pw. New environment variables for the default path.
     Refuse atomic replacement of files when quotas are enabled.
     Accept pure-pw mkdb without any further argument.
     New pid_file glob.
@@ -1230,7 +1230,7 @@ zones, zerofill hour/min/sec to 2 digits.
     Corrected the german translation for grammatical/spelling errors,
 translated missing messages. -Contributed by Bernhard Weisshuhn.
     Danish translation. -Contributed by Isak Lyberth.
-    Log login attemps with disabled accounts. Admin can still check what's
+    Log login attempts with disabled accounts. Admin can still check what's
 wrong even --with-paranoidmsg . The new message is MSG_DISABLED_ACCOUNT.
     Improved pure-config.pl.in : extra parameters can be added in command
 line.
@@ -1261,7 +1261,7 @@ Thanks to Vincent the Herisson
     Have RNTO work when the target file name already exists - Reported by
 Bernhard Weisshuhn.
     Allow transfers through sendfile() longer than <idletime> , needed for
-very large files transfered over slow links (odd idea, but why not) .
+very large files transferred over slow links (odd idea, but why not) .
     Changed the trustedgid behavior when the /./ trick is used : members of
 the trusted group *are* chrooted, but they have no ratio and dot-files are
 allowed.
@@ -1360,7 +1360,7 @@ to accept non-anonymous connections.
     Open the syslog as soon as possible (before accepting client
 connections) . It solves the nasty long-standing syslog-output-in-client-fd
 bug.
-    Dont localtime(NULL), it crashes under FreeBSD.
+    Don't localtime(NULL), it crashes under FreeBSD.
 
 * Version 0.98.3 :
     Close listenfd, but close(2) only if it's a tty (maybe it's an
@@ -1424,7 +1424,7 @@ xfer_date to the FTPWhoEntry structure.
     New output targets : shell (-s) and verbose ASCII (-v) .
     Paranoia : add more entropy to the zrand() function.
     Changed u_mask default to 133, uploaded files are now 777.
-    bandwidth_throttling was splitted into bandwidth_throttling_ul and
+    bandwidth_throttling was split into bandwidth_throttling_ul and
 bandwidth_throttling_dl.
     Syslog is now opened after forking. It fixes the nasty syslog-to-
 clientconn bug due to dup2() and/or syslog mutex internals.
@@ -1527,7 +1527,7 @@ can work without root privileges.
     Added --with-language.
     Fixed largefile+throttling compilation.
     Changed 'quota' to 'ratio' everywhere. Quotas will be something else.
-    Create /var/run/pure-ftpd.pid . Remove it when a signal is catched.
+    Create /var/run/pure-ftpd.pid . Remove it when a signal is caught.
     Added romanian translation from Claudiu Costin <claudiuc at kde.org>.
     Added german translation from Mathias Gumz <gumz at cs.uni-magdeburg.de>.
     Added french translation from Ping <ping at root42.net>.
@@ -1576,7 +1576,7 @@ stdin/stdout/stderr.
     Accept non-ascii (accents) file names (check if <32U in checknamesanity).
     Added dynamic.c for IP tracking. Yes, the code could be optimized for
 speed with two hashed tables (ip->number pid->link to the previous table).
-But it's simple and fast enough if you don't have 500000000 simultanous
+But it's simple and fast enough if you don't have 500000000 simultaneous
 users (and if you do, you have a high end machine, don't you?) .
     Added '-E' flag. anon_only = 0 (normal mode) -1 (no anon) or +1 (anon
 only) .
@@ -1672,7 +1672,7 @@ where we started if we reached a limit.
     Avoid loops in directory listings.
 
 * Version 0.96pre1 :
-    Added '-P' flag to explicitely set an IP address in reply to a PASV
+    Added '-P' flag to explicitly set an IP address in reply to a PASV
 command.
     Added '-A' flag to chroot() everyone. If '-A' is combined with '-a', the
 last option takes precedence.
@@ -1741,7 +1741,7 @@ reflect the change.
     Added a generic basic parser (parser.*), currently only used for LDAP.
     Disallow command-line options whose support isn't compiled-in.
     Documented Xinetd configuration and the Netfilter troubles.
-    Added a check for the 'guage' typo instead of 'gauge' on some old Dialog
+    Added a check for the 'gauge' typo instead of 'gauge' on some old Dialog
 versions.
 
 * Version 0.95-pre4 :

--- a/FAQ
+++ b/FAQ
@@ -482,7 +482,7 @@ Also see the 'Global bandwidth limitation' section later in this document.
 
 * KERBEROS_V4 rejected as an authentication type.
 
--> It works and I can log in, but I recieve these strange error messages at
+-> It works and I can log in, but I receive these strange error messages at
 log in, even in a non-chrooted environment: 
 
 220 FTP server ready. 
@@ -805,7 +805,7 @@ kernels. Have a look at http://linux-ntfs.sf.net/ .
 
 * Slowdowns and lags.
 
--> Some users complains that transfering large files doesn't work. Transfers
+-> Some users complains that transferring large files doesn't work. Transfers
 are starting as expected, with a decent rate. But then, the speed dramatically
 decreases, there are some serious lags and they often must disconnect (or the
 client force them to do it, after a timeout) . The server is behind a firewall
@@ -833,7 +833,7 @@ sysctl -w net.ipv4.tcp_bic=0
 
 -> My client is behind a stateful firewall doing applicative filtering (like
 IPTables with ip_conntrack_ftp or ip_nat_ftp) . Connections to an TLS
-enabled server does't work. Authentication works, but I'm unable to download
+enabled server doesn't work. Authentication works, but I'm unable to download
 files nor list directories.
 
 First, try to force your client to use the passive mode. In active mode, the

--- a/NEWS
+++ b/NEWS
@@ -66,10 +66,10 @@ client certificates mandatory. This is no longer a compile-time option.
 passwords. This is the preferred algorithm, but requires the presence
 of libsodium.
  - LDAP uid and gid values can over overridden in the LDAP configuration file.
- - Support for LDAP over TLS (LDAPUseTLS in the configuratoin file) was added.
+ - Support for LDAP over TLS (LDAPUseTLS in the configuration file) was added.
 
 * Version 1.0.36:
- - Support for external authentification handlers has been fixed.
+ - Support for external authentication handlers has been fixed.
 Reported by Rasmus Fauske.
  - Directory listings can now report file sizes up to 1 exabyte.
  - Pure-FTPd is now useable on Win32 again.
@@ -230,7 +230,7 @@ Contributed by Old Sparky.
  - Support for large files is now enabled by default, with no slowdown on
 Linux.
  - SITE UTIME and OPTS MLST have been implemented.
- - Huge performance improvement while transfering a lot of small files.
+ - Huge performance improvement while transferring a lot of small files.
  - Better handling of aborted transfers.
  - MySQL queries can now include multiple statements (MysQL 4.1 and later)
 and call MySQL 5 stored procedures. Thanks to Mike Goins.
@@ -292,8 +292,8 @@ used.
  - Upload is now atomic. A file is uploaded with a temporary name and it gets
 its final name only once the upload has been completed. If a file already
 exists with the same name, the content can be preserved until the new content
-has been fully transfered (using the new --notruncate run-time switch). Web
-servers will no more serve partially transfered files during uploads.
+has been fully transferred (using the new --notruncate run-time switch). Web
+servers will no more serve partially transferred files during uploads.
   The new handling of uploads also limits the races in virtual quota handling.
 
 * Version 1.0.16c:
@@ -333,7 +333,7 @@ handling of upload scripts, to the pure-pw command and to the
 automatic creation of home directories.
  - Accounts in a puredb database can now be quickly listed ("pure-pw
 list").
- - The anonymous FTP directory can now be overriden on the Windows
+ - The anonymous FTP directory can now be overridden on the Windows
 port (using a WIN32_ANON_DIR environment variable).
  - The default banner has been stripped down to look more
 professionnal (ie. boring).
@@ -616,7 +616,7 @@ pure-quotacheck) . Please read the "virtual quotas" section in README.
 <tomo@t-square.jp>
  - The memory footprint for uploads has been slightly reduced, especially
 when bandwidth throttling is enabled. Thanks to Daniel Tschan.
- - Virtual users (FTP-only local user list, independant of /etc/passwd) were
+ - Virtual users (FTP-only local user list, independent of /etc/passwd) were
 implemented. Every user can have different bandwidth, quota and ratio.
 
 * Version 0.99.1b
@@ -784,7 +784,7 @@ permissions problem introduced in 0.98.
  - Actually include the polish translation.
  - Spanish translation (Luis Llorente Campo). 
  - Renamed mrtginfo to pure-mrtginfo.
- - The default umask is now 133. By explicitely setting the mask to 022,
+ - The default umask is now 133. By explicitly setting the mask to 022,
 uploaded files can become executable.
  - Logging can be disabled (-f none) .
  - Upload and download bandwidth can now be throttled separately.
@@ -863,7 +863,7 @@ password to anonymous clients.
  - Stabilized the standalone code.
  - New '-E' option to disallow anon login even if ~ftp exists (Suggested by
 Daniel Elsaesser) .
- - New '-C' option to limit the number of simultanous connections from the
+ - New '-C' option to limit the number of simultaneous connections from the
 same client IP address.
 
 * Version 0.97pre5
@@ -911,7 +911,7 @@ client doesn't send the '-a' option (ls -la) .
  - Better support for broken NAT gateways.
 
 * Version 0.96pre1
- - Added '-P' flag (explicitely set an IP address in reply to a PASV
+ - Added '-P' flag (explicitly set an IP address in reply to a PASV
 command), '-A' flag (to chroot() everyone) and  '-H' flag (to avoid DNS
 resolution), '-U' flag (to limit the maximum depth of a recursive 'ls' and
 the maximum number of displayed files) and '-M' flag (allow anonymous users

--- a/README
+++ b/README
@@ -206,7 +206,7 @@ that prefix. But you must also add an /etc directory (readable and writeable
 by the user pure-ftpd will run as) . You can change the anonymous FTP root
 directory through an environment variable named FTP_ANON_DIR.
 
---with-pam: use pluggable authentification modules. Don't use this option
+--with-pam: use pluggable authentication modules. Don't use this option
 if your login/passwd pairs are always refused (but the real fix would be to
 fix your PAM configuration). You need to create a /etc/pam.d/pure-ftpd file
 to properly use the PAM authentication. The 'pam' directory contains an
@@ -284,7 +284,7 @@ by default.
 over the iconv library and it requires a little more CPU time. See the -8
 and -9 switches.
 
---with-implicittls: build a FTPS server (TLS is implicitely enabled).
+--with-implicittls: build a FTPS server (TLS is implicitly enabled).
 The protocol is incompatible with FTP and listens to another port by default
 (port 990, ftps). Never enable this option unless you know what you're doing.
 
@@ -443,7 +443,7 @@ or
 
 /usr/local/sbin/pure-ftpd -S ftp.example.com,21 -c 50 &
 
-And only 50 simultanous connections will be allowed. To discover what
+And only 50 simultaneous connections will be allowed. To discover what
 options are available please jump to the 'OPTIONS' chapter below. If the
 server runs perfectly for you in standalone mode, you don't need to read the
 following chapter about super-servers. But read the options. '-m' and '-C'
@@ -618,8 +618,8 @@ file with the same name, the old file will neither get removed nor truncated.
 Upload will take place in a temporary file and once the upload is complete,
 the switch to the new version will be atomic. For instance, when a large PHP
 script is being uploaded, the web server will still serve the old version and
-immediatly switch to the new one as soon as the full file will have been
-transfered.
+immediately switch to the new one as soon as the full file will have been
+transferred.
 
 - '-1': log the PID of each session in syslog output.
 
@@ -654,7 +654,7 @@ symbolic links are shown as real files/directories.
 instance '-c 42' will limit access to simultaneous 42 clients. There is a
 50 client limit by default.
 
-- '-C <max connection per ip>': Limit the number of simultanous connections
+- '-C <max connection per ip>': Limit the number of simultaneous connections
 coming from the same IP address. This is yet another very effective way to
 prevent stupid denial of services and bandwidth starvation by a single user.
 It works only when the server is launched in standalone mode (if you use a
@@ -891,7 +891,7 @@ INTERNAL SERVER, BUT _DON'T_ GIVE FXP ACCESS TO ANONYMOUS INTERNET USERS.
 ****************************************************************************
 
         It's why FXP is disabled by default on Pure-FTPd unless you
-explicitely enable it with '-W' or '-w'.
+explicitly enable it with '-W' or '-w'.
 
 - '-x': In normal operation mode, authenticated users can read/write files
 beginning with a dot ('.') . Anonymous users can't, for security reasons
@@ -1288,7 +1288,7 @@ The FTP protocol doesn't allow name-based selection. So, if you want to host
 <N> different virtual FTP servers on the same host and keep the standard port,
 you need <N> different IP addresses. Yes, Sir. Or use HTTP.
 
-Assign the needed IP adresses to your network adapter (with "ifconfig eth0:x
+Assign the needed IP addresses to your network adapter (with "ifconfig eth0:x
 ..." or "ip addr add dev eth0 a.b.c.d").
 
 Now, create a /etc/pure-ftpd directory if it doesn't exist:
@@ -1434,7 +1434,7 @@ sample output of 'pure-ftpwho -v':
 +------+---------+-------+------+-------------------------------------------+
 | 9086 | j       | 00:04 |  DL  | linux-2.4.4.tar.bz2                       |
 |  ''  |    ''   |  22K/s|  27% | ->                              localhost |
-|  ''  |    ''   |       |      | Total size:    20859 Transfered:     5632 |
+|  ''  |    ''   |       |      | Total size:    20859 Transferred:     5632 |
 |  ''  |    ''   |       |      | <-                        localhost:21    |
 +------+---------+-------+------+-------------------------------------------+
 
@@ -1465,7 +1465,7 @@ For security purposes, the server never launches any external program. It's
 why there is a separate daemon, that reads new uploads pushed into a named
 pipe by the server. Uploads are processed synchronously and sequencially.
 It's why on loaded or untrusted servers, it might be a bad idea to use
-pure-uploadscript with lenghty or cpu-intensive scripts.
+pure-uploadscript with lengthy or cpu-intensive scripts.
 
 The easiest way to run pure-uploadscript is 'pure-uploadscript -r <script>':
 
@@ -1686,7 +1686,7 @@ To define alias/directory pairs, you must create a file called
 /etc/pureftpd-dir-aliases, whose format is:
 
 Alternating lines of alias and dir
-(this enables embeded whitespace in dir and alias without quoting rules)
+(this enables embedded whitespace in dir and alias without quoting rules)
 Optional blank lines
 Optional lines beginning with '#' as comments
 (no you can't put a '#' just anywhere)
@@ -1888,7 +1888,7 @@ And what if a customer uploads a script to your server and thinks he can
 safely delete it from its hard disk? If the remote file is corrupted, he
 will get really angry.
 It's why Pure-FTPd *refuses* to resume ASCII transfers. If a customer tells
-you that he isn't able to upload/download a partially transfered ASCII file,
+you that he isn't able to upload/download a partially transferred ASCII file,
 please tell them to remove the partial file and to retransfer it again. This
 is a safe bet.
 

--- a/README.Contrib
+++ b/README.Contrib
@@ -70,7 +70,7 @@ http://pureuseradmin.sourceforge.net/
 
 PureUserAdmin is a PHP based webbased application. Sys admins can use it to
 easily manage the virtual users for their FTP server. PureUserAdmin is
-developped to be used with Pure-FTPd but it should be able to be used with
+developed to be used with Pure-FTPd but it should be able to be used with
 other FTP servers as long as the FTP server gets the useraccount info from
 MySQL or PostgreSQL.
 

--- a/README.Virtual-Users
+++ b/README.Virtual-Users
@@ -213,7 +213,7 @@ Max sim sessions   : 0 (unlimited)
   "/./" at the end of a home directory means that this user will be chrooted.
 
 
-     ------------------------ COMMITING CHANGES ------------------------
+     ------------------------ COMMITTING CHANGES ------------------------
       
 
 IMPORTANT:
@@ -222,7 +222,7 @@ You can add, modify and delete users with the previous commands, or by
 editing /etc/pureftpd.passwd by hand. But the FTP server won't consider the
 changes you make to that file, until you commit them.
 
-Commiting changes really means that a new file is created from
+Committing changes really means that a new file is created from
 /etc/pureftpd.passwd (or whatever file name you choose) . That new file is a
 PureDB file. It contains exactly the same info than the other file. But in
 that file, accounts are sorted and indexed for faster access, even with
@@ -242,7 +242,7 @@ For instance:
   pure-pw mkdb /etc/accounts/myaccounts.pdb -f /etc/accounts/myaccounts.txt
 
 All modifications you made to the virtual users database will be committed
-atomatically: all new accounts will be activated at the same time and all
+automatically: all new accounts will be activated at the same time and all
 deleted users won't be able to log in as soon as you'll have hit the Return
 key.
 

--- a/contrib/pure-stat.pl
+++ b/contrib/pure-stat.pl
@@ -101,7 +101,7 @@ close LOG;
 #PARSING  ARRAY IF NOT EMPTY
 if ($#loglist != -1)
 {
-	#GENERATE FILE EXTENSTION AS yearmonthmdayhourmin
+	#GENERATE FILE EXTENSION AS yearmonthmdayhourmin
 	@dlist = gmtime(time);
 	$ext = sprintf("%02d%02d%02d%02d%02d", $dlist[5], $dlist[4]+1, $dlist[3], $dlist[2]+2, $dlist[1]);
 	undef @dlist;

--- a/man/pure-ftpd.8.in
+++ b/man/pure-ftpd.8.in
@@ -196,7 +196,7 @@ to use
 as primary overload protection. The default value is 50.
 .TP
 .B \-C max connection per ip
-Limit the number of simultanous connections
+Limit the number of simultaneous connections
 coming from the same IP address. This is yet another very effective way to
 prevent stupid denial of services and bandwidth starvation by a single user.
 It works only when the server is launched in standalone mode (if you use a
@@ -472,7 +472,7 @@ or
 .B \-T upload bandwidth:download bandwidth
 Enable process priority lowering and bandwidth throttling for *ALL*
 users.
-Pure\-FTPd should have been explicitely compiled with throttling support
+Pure\-FTPd should have been explicitly compiled with throttling support
 to have these flags work.
 It is possible to have different bandwidth limits for uploads and for
 downloads. '\-t' and '\-T' can indeed be followed by two numbers delimited by
@@ -565,7 +565,7 @@ Add safe guards against common customer mistakes (like chmod 0 on their own file
 .SH "AUTHENTICATION"
 Some of the complexities of older servers are left out.
 .PP
-This version of pure\-ftpd can use PAM for authentication. If you wan't it to
+This version of pure\-ftpd can use PAM for authentication. If you want it to
 consult any files like /etc/shells or /etc/ftpd/ftpusers consult pam
 docs. LDAP directories and SQL databases are also supported.
 .PP

--- a/man/pure-ftpwho.8.in
+++ b/man/pure-ftpwho.8.in
@@ -42,7 +42,7 @@ It's not very human-readable, but it's designed for easy parsing by shell script
 \fB\-v\fR
 Output an ASCII table (just like the default mode), with more info.
 The verbose output includes the local IP, the local port, the total size of
-transfered files and the current number of transfered bytes.
+transferred files and the current number of transferred bytes.
 .TP 
 \fB\-w\fR
 Output a complete HTML page (web mode).

--- a/pure-ftpd.conf.in
+++ b/pure-ftpd.conf.in
@@ -398,7 +398,7 @@ CustomerProof                yes
 # complete, it will be atomically renamed. For example, when a large PHP
 # script is being uploaded, the web server will keep serving the old version and
 # later switch to the new one as soon as the full file will have been
-# transfered. This option is incompatible with virtual quotas.
+# transferred. This option is incompatible with virtual quotas.
 
 # NoTruncate                   yes
 

--- a/puredb/README
+++ b/puredb/README
@@ -14,7 +14,7 @@ key/data pairs of arbitrary sizes. Lookups are very fast (normally only one
 disk access to match a hash value), overhead is low (a database is 1028
 bytes plus only 16 extra bytes per record), multiple concurrent read access
 are supported, databases can be up to 4 Gb long, and they are portable
-accross architectures. 
+across architectures. 
 
 
         ------------------------ COMPILATION ------------------------
@@ -207,7 +207,7 @@ first byte of the matching data, and retlen is the length of the data.
 Return value: 0 if the key was found.
              -1 if the key was not found.
              -2 if the database is corrupted.
-             -3 if a system error occured.
+             -3 if a system error occurred.
 
 
 
@@ -220,7 +220,7 @@ strlen(tofind) as a key length.
 Return value: 0 if the key was found.
              -1 if the key was not found.
              -2 if the database is corrupted.
-             -3 if a system error occured.
+             -3 if a system error occurred.
 
 
 

--- a/src/diraliases.c
+++ b/src/diraliases.c
@@ -2,7 +2,7 @@
 
 0) alias file format.
  alternating lines of alias and dir
- (this enables embeded whitespace in dir and alias without quoting rules)
+ (this enables embedded whitespace in dir and alias without quoting rules)
  optional blank lines
  optional lines beginning with '#' as comments
  (no you can't put a '#' just anywhere)

--- a/src/fakesnprintf.c
+++ b/src/fakesnprintf.c
@@ -14,8 +14,8 @@
  * - floating point frac restrictions ("%.2f") .
  * - combinations of everything ("%-8.5llo") .
  *
- * Nothing more. Return value is <size> if an overflow occured, or the
- * copied size if no overflow occured (mostly compatible with C99
+ * Nothing more. Return value is <size> if an overflow occurred, or the
+ * copied size if no overflow occurred (mostly compatible with C99
  * snprintf() behavior, except that it doesn't return any value larger
  * than <size>).
  *

--- a/src/log_pam.c
+++ b/src/log_pam.c
@@ -59,7 +59,7 @@ static const char *PAM_username;
 static const char *PAM_password;
 static int PAM_error;
 
-/* for compability with older pam stuff, before the stupid transposition */
+/* for compatibility with older pam stuff, before the stupid transposition */
 #ifndef PAM_CRED_ESTABLISH
 # define PAM_CRED_ESTABLISH  0x0002U
 #endif

--- a/src/pure-ftpwho.c
+++ b/src/pure-ftpwho.c
@@ -187,11 +187,11 @@ static void text_output_line(const pid_t pid, const char * const account,
     if (verbose != 0) {
         if (current_size > 0) {
             if (total_size > 0) {
-                printf("|  ''  |    ''   |       |      | Total size:%9llu Transfered:%9llu |\n",
+                printf("|  ''  |    ''   |       |      | Total size:%9llu Transferred:%9llu |\n",
                        (unsigned long long) (total_size / 1024),
                        (unsigned long long) (current_size / 1024));
             } else {
-                printf("|  ''  |    ''   |       |      | Transfered: %-29llu |\n",
+                printf("|  ''  |    ''   |       |      | Transferred: %-29llu |\n",
                        (unsigned long long) (current_size / 1024));
             }
         }


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.