### PR TITLE
Fix STAT on TLS connections

### DIFF
--- a/src/ls.c
+++ b/src/ls.c
@@ -58,7 +58,7 @@ static void wrstr(const int f, void * const tls_fd, const char *s)
         l -= rest;
     }
 #ifdef WITH_TLS
-    if (data_protection_level == CPL_PRIVATE) {
+    if (tls_fd != NULL) {
         if (secure_safe_write(tls_fd, outbuf, sizeof outbuf) !=
             (ssize_t) sizeof outbuf) {
             return;
@@ -72,7 +72,7 @@ static void wrstr(const int f, void * const tls_fd, const char *s)
         }
     }
 #ifdef WITH_TLS
-    if (data_protection_level == CPL_PRIVATE) {
+    if (tls_fd != NULL) {
         while (l > sizeof outbuf) {
             if (secure_safe_write(tls_fd, s, sizeof outbuf) !=
                 (ssize_t) sizeof outbuf) {
@@ -889,7 +889,7 @@ void donlist(char *arg, const int on_ctrl_conn, const int opt_l_,
     } else {                           /* STAT command */
         c = clientfd;
 #ifdef WITH_TLS
-        if (data_protection_level == CPL_PRIVATE) {
+        if (tls_cnx != NULL) {
             secure_safe_write(tls_cnx, "213-STAT" CRLF,
                               sizeof "213-STAT" CRLF - 1U);
             tls_fd = tls_cnx;


### PR DESCRIPTION
The STAT command output get sent unencrypted on the control socket (thus
breaking the proper TLS stream) unless the client enabled private protection
for the data socket via the PROT command.

The problem is easly reproducible:

$ openssl s_client -connect 127.0.0.1:1256 -starttls ftp
220 You will be disconnected after 15 minutes of inactivity.
user
230 Anonymous user logged in
stat a
140316490120920:error:1408F10B:SSL routines:SSL3_GET_RECORD:wrong version number:s3_pkt.c:362:

OpenSSL s_client throws an error since pure-ftpd replied "213-STAT" directly
on the TCP stream, in plain text, instead of witing it inside the TLS tunnel.

The current code also allows a null pointer dereference: if you start TLS via
AUTH TLS, then login, enable data socket protection (PROT P) and end TLS on
control socket (CCC), a following STAT with argument will pass tls_cnx to
SSL_write (ls.c:893), which was nulled by CCC command (ftp_parser.c:409).