### PR TITLE
path fixing

### DIFF
--- a/pure-ftpd.conf.in
+++ b/pure-ftpd.conf.in
@@ -9,7 +9,7 @@
 # instead of command-line options, please run the
 # following command :
 #
-# @prefix@/sbin/pure-ftpd @sysconfdir@/etc/pure-ftpd.conf
+# @prefix@/sbin/pure-ftpd @sysconfdir@/pure-ftpd.conf
 #
 # Online documentation:
 # https://www.pureftpd.org/project/pure-ftpd/doc


### PR DESCRIPTION
Hello,

this is small path fixing
we don't need this '/etc' in path because 
sysconfdir = prefix + '/etc'
