### PR TITLE
Allow TLS 1.3 and 1.2 to be disabled

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -300,7 +300,10 @@ int tls_init_library(void)
     SSL_CTX_set_options(tls_ctx, SSL_OP_NO_TLSv1_1);
 # endif
 # ifdef SSL_OP_NO_TLSv1_2
-    SSL_CTX_clear_options(tls_ctx, SSL_OP_NO_TLSv1_2);
+    SSL_CTX_set_options(tls_ctx, SSL_OP_NO_TLSv1_2);
+# endif
+# ifdef SSL_OP_NO_TLSv1_3
+    SSL_CTX_set_options(tls_ctx, SSL_OP_NO_TLSv1_3);
 # endif
     if (tlsciphersuite != NULL) {
         if (SSL_CTX_set_cipher_list(tls_ctx, tlsciphersuite) != 1) {


### PR DESCRIPTION
This PR fixes the same error for TLS 1.2 as aa68b2d620ef0c83c7f52213c7e6093722b0b8bd did for TLS 1.1 and adds define also for TLS 1.3 as listed in [list of SSL OP flags](https://wiki.openssl.org/index.php/List_of_SSL_OP_Flags).