### PR TITLE
Allow client to gracefully fail-over for non-TLS sessions

### DIFF
--- a/src/ftp_parser.c
+++ b/src/ftp_parser.c
@@ -326,7 +326,8 @@ void parser(void)
         if (!strcmp(cmd, "user")) {
 #ifdef WITH_TLS
             if (enforce_tls_auth > 1 && tls_cnx == NULL) {
-                die(421, LOG_WARNING, MSG_TLS_NEEDED);
+                addreply(421, MSG_TLS_NEEDED);
+                goto wayout;
             }
 #endif
             douser(arg);


### PR DESCRIPTION
Instead of disconnecting the client when a TLS session has not been established yet, allow the client to gracefully "fail-over" to an encrypted session (by sending an AUTH TLS command). This behavior also corresponds with the error code (421) which belongs to "4xx Transient Negative Completion reply" category, which indicates that the error condition is temporary.