### PR TITLE
Force Passive IP is useful for enforcing the address where data conne…

### DIFF
--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -2138,6 +2138,9 @@ void dopasv(int psvtype)
     }
     dataconn = ctrlconn;
     for (;;) {
+        if (STORAGE_FAMILY(force_passive_ip) == AF_INET) {
+            STORAGE_SIN_ADDR(dataconn) = STORAGE_SIN_ADDR(force_passive_ip);
+        }
         if (STORAGE_FAMILY(dataconn) == AF_INET6) {
             STORAGE_PORT6(dataconn) = htons(p);
         } else {


### PR DESCRIPTION
…ctions are spawned. Instead of just reporting it to remote, now force listening exactly on this address (probably as desired by user who'd set -P x.y.z.a).

Please consider the attached patch.
With it pure-ftpd seems to work correctly behind a balancer (traefik).
Consider the following scenario:
FTPCLIENT->[TCP BALANCER(traefik)]->[Container PUREFTPD1, IP1],[Container PUREFTPD, IP2],[etc...]

Example from container with two interfaces:
root@1a4f12124b42:/usr/local/sbin# ip ro ls
default via 10.0.100.1 dev eth0
10.0.44.0/24 dev eth1  proto kernel  scope link  src 10.0.44.15
10.0.100.0/22 dev eth0  proto kernel  scope link  src 10.0.100.70

Attempt to initiate a PASV data connection from ftp client (netstat in container):
root@eb23f6034dd2:/# ss -napt
State       Recv-Q Send-Q                   Local Address:Port                     Peer Address:Port
LISTEN      0      128                                  *:21*                                  :*      users:(("pure-ftpd",pid=75,fd=3),("pure-ftpd",pid=27,fd=3))
LISTEN      0      8                            10.0.42.3:39927                               *:*
LISTEN      0      128                         127.0.0.11:44357                               *:*
ESTAB       0      0                            10.0.42.3:21                          10.0.42.9:34538  users:(("pure-ftpd",pid=75,fd=5))
LISTEN      0      128                                 :::21                                 :::*      users:(("pure-ftpd",pid=75,fd=4),("pure-ftpd",pid=27,fd=4))

pure-ftpd is started with -P 10.0.100.70, yet for passive data connections it listens on 10.0.42.3.
In other words '-P' forces the passive IP1, but up to now pure-ftpd still binds and listens on the IP where the control connection had begun (in our example through eth1 10.0.44.0/24 (traefik)) .
Since it's an internal network not visible to the ftp client the data transfer is not possible and client gets 'connection refused'.

With this patch force_passive_ip is used explicitly for binding and now the passive data connection is successful (netstat inside container):
root@1a4f12124b42:/usr/local/sbin# ss -napt
State       Recv-Q Send-Q                   Local Address:Port                     Peer Address:Port
LISTEN      0      8                          10.0.100.70:39179                               *:*
LISTEN      0      128                         127.0.0.11:44907                               *:*
LISTEN      0      128                                  *:21                                  *:*      users:(("pure-ftpd",pid=534,fd=4),("pure-ftpd",pid=520,fd=4))
ESTAB       0      0                           10.0.44.15:21                          10.0.44.7:58704  users:(("pure-ftpd",pid=534,fd=6))
ESTAB       0      149752                     10.0.100.70:39179                    10.0.103.248:55582
LISTEN      0      128                                 :::21                                 :::*      users:(("pure-ftpd",pid=534,fd=5),("pure-ftpd",pid=520,fd=5))