### PR TITLE
Add runtime support for disabling ascii transfers

### DIFF
--- a/README
+++ b/README
@@ -961,6 +961,7 @@ aliases are available. You can get this list at any time by typing
 -1  --logpid                <file>
 -4  --ipv4only
 -6  --ipv6only
+-7  --disableascii
 -8  --fscharset             <charset>
 -9  --clientcharset         <charset>
 -a  --trustedgid            <gid>
@@ -1041,6 +1042,7 @@ aliases are available. You can get this list at any time by typing
 -Z  --customerproof
 
 -B  --daemonize 
+-7  --disableascii
 -D  --displaydotfiles   
 -H  --dontresolve   
 

--- a/man/pure-ftpd.8.in
+++ b/man/pure-ftpd.8.in
@@ -26,6 +26,8 @@ Alternative style:
 .br
 \-6 \-\-ipv6only
 .br
+\-7 \-\-disableascii
+.br
 \-a \-\-trustedgid
 .br
 \-A \-\-chrooteveryone
@@ -152,7 +154,7 @@ the switch to the new version will be atomic. This option should not be used
 together with virtual quotas.
 .TP
 .B \-1
-Add the PID to the syslog output. Ignored if 
+Add the PID to the syslog output. Ignored if
 .B -f
 .B none
 is set.
@@ -170,6 +172,9 @@ Listen only to IPv4 connections.
 .TP
 .B \-6
 Listen only to IPv6 connections.
+.TP
+.B \-7
+Disable ASCII file transfers.
 .TP
 .B \-a gid
 Regular users will be chrooted to their home directories, unless
@@ -978,7 +983,7 @@ Contributors:
  Philip Gladstone,
  Kenneth Stailey,
  Brad Smith,
- Ulrik Sartipy, 
+ Ulrik Sartipy,
  Cindy Marasco,
  Nicolas Doye,
  Thomas Briggs,

--- a/pure-ftpd.conf.in
+++ b/pure-ftpd.conf.in
@@ -384,6 +384,12 @@ CustomerProof                yes
 
 
 
+# This option prevents users from initiating ASCII transfers
+
+# DisableAsciiTransfers        yes
+
+
+
 # Per-user concurrency limits. Will only work if the FTP server has
 # been compiled with --with-peruserlimits.
 # Format is: <max sessions per user>:<max anonymous sessions>

--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -3106,7 +3106,7 @@ static int dl_dowrite(DLHandler * const dlhandler, const unsigned char *buf_,
         return -1;
     }
 #ifndef WITHOUT_ASCII
-    if (dlhandler->ascii_mode > 0) {
+    if (disable_ascii == 0 && dlhandler->ascii_mode > 0) {
         unsigned char *asciibufpnt;
         size_t z = (size_t) 0U;
 
@@ -5612,6 +5612,10 @@ int pureftpd_start(int argc, char *argv[], const char *home_directory_)
             break;
         }
 #endif
+        case '7': {
+            disable_ascii = 1;
+            break;
+        }
         case 'a': {
             const char *nptr;
             char *endptr;

--- a/src/ftpd_p.h
+++ b/src/ftpd_p.h
@@ -115,6 +115,7 @@ static struct option long_options[] = {
 # endif
     { "ipv4only", 0, NULL, '4' },
     { "ipv6only", 0, NULL, '6' },
+    { "disableascii", 0, NULL, '7' },
     { "chrooteveryone", 0, NULL, 'A' },
     { "trustedgid", 1, NULL, 'a' },
     { "brokenclientscompatibility", 0, NULL, 'b' },

--- a/src/globals.h
+++ b/src/globals.h
@@ -45,6 +45,7 @@ GLOBAL0(signed char userchroot); /* 0=don't chroot() by default for regular
 GLOBAL0(signed char chrooted);   /* if we already chroot()ed */
 GLOBAL0(uid_t chroot_trustedgid);
 GLOBAL0(signed char broken_client_compat); /* don't enable workarounds by default */
+GLOBAL0(signed char disable_ascii);    /* disable support for ascii transfers */
 GLOBAL0(uid_t warez);                  /* don't guard against warez */
 GLOBAL0(signed char debug);            /* don't give debug output */
 GLOBAL0(signed char guest);            /* if non-zero, it's a guest user */

--- a/src/simpleconf_ftpd.h
+++ b/src/simpleconf_ftpd.h
@@ -24,6 +24,7 @@ static const SimpleConfEntry simpleconf_options[] = {
     {"CreateHomeDir? <bool>",                     "--createhomedir"},
     {"CustomerProof? <bool>",                     "--customerproof"},
     {"Daemonize? <bool>",                         "--daemonize"},
+    {"DisableAsciiTransfers? <bool>",             "--disableascii"},
     {"DisplayDotFiles? <bool>",                   "--displaydotfiles"},
     {"DontResolve? <bool>",                       "--dontresolve"},
     {"ExtCert (<any*>)",                          "--extcert=$0"},


### PR DESCRIPTION
I need to disable ascii transfers since I have some users that are trying to send zip files using ASCII mode, but I also don't want to have to maintain a source version of my FTP software on my server. So I'd like this change to get merged upstream so that eventually I have this configuration option available.