### PR TITLE
configure: Use AM_PROG_AR to improve portability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ Makefile
 Makefile.in
 Vagrantfile
 aclocal.m4
+ar-lib
 autom4te.cache
 clang_output_*
 compile

--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AC_INIT([pure-ftpd],[1.0.49],
   [https://www.pureftpd.org])
 AC_CONFIG_SRCDIR(src/ftpd.c)
 AC_CONFIG_HEADERS([config.h])
-AM_INIT_AUTOMAKE([1.9 dist-bzip2 tar-ustar])
+AM_INIT_AUTOMAKE([1.11.2 dist-bzip2 tar-ustar])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AM_MAINTAINER_MODE
 AM_DEP_TRACK
@@ -17,6 +17,7 @@ AC_SUBST(VERSION)
 
 dnl Checks for programs.
 LX_CFLAGS=${CFLAGS-NONE}
+AM_PROG_AR
 AC_PROG_CC
 AC_PROG_RANLIB
 AC_USE_SYSTEM_EXTENSIONS


### PR DESCRIPTION
The AM_PROG_AR macro was added in Automake 1.11.2 thus the minimum
Automake version is increased.

Downstream-Bug: https://bugs.gentoo.org/721242
