### PR TITLE
Error: Carriage return without line feed received

### DIFF
--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -3527,11 +3527,11 @@ void dofeat(void)
     char feat[] = FEAT FEAT_DEBUG FEAT_TLS FEAT_TVFS FEAT_ESTA FEAT_PASV FEAT_ESTP;
 
     if (disallow_passive != 0) {
-        feat[sizeof FEAT FEAT_DEBUG FEAT_TLS FEAT_TVFS FEAT_ESTA] = 0;
+        feat[sizeof FEAT FEAT_DEBUG FEAT_TLS FEAT_TVFS FEAT_ESTA - 1U] = 0;
     }
 # ifndef MINIMAL
     else if (STORAGE_FAMILY(force_passive_ip) != 0) {
-        feat[sizeof FEAT FEAT_DEBUG FEAT_TLS FEAT_TVFS FEAT_ESTA FEAT_PASV] = 0;
+        feat[sizeof FEAT FEAT_DEBUG FEAT_TLS FEAT_TVFS FEAT_ESTA FEAT_PASV - 1U] = 0;
     }
 # endif
     addreply_noformat(0, feat);


### PR DESCRIPTION
While altering `Feat` array, we leave out `\r` which raises error because we get (* is cursor) -

> ...
> _ESTA
> _PASV
> *EPSV

instead of

> ...
> _ESTA
> _PASV
> _EPSV*

in the later stage new-line is added when clubbing FEAT and remaining message.

Tested on https://ftptest.net (with -P parameter i.e. force_passive_ip) before and after this change.