### PR TITLE
pure-pw: pureftpd.passwd.tmp can be written error

### DIFF
--- a/src/pure-pw.c
+++ b/src/pure-pw.c
@@ -584,6 +584,11 @@ static FILE *create_newpasswd(const char * const file,
     char line[LINE_MAX];
 
     fp = fopen(file, "r");
+
+    if (access(file2, F_OK) == 0) {
+        remove(file2);
+    }
+
     if ((fd2 = open(file2, O_EXCL | O_NOFOLLOW |
                     O_CREAT | O_WRONLY, (mode_t) 0700)) == -1) {
         if (fp != NULL) {


### PR DESCRIPTION
If for some reason the file is not deleted ,then "pure-pw" will return an error.

How to reproduce the problem:
* Create a file `pureftpd.passwd.tmp`
```bash
$ touch /etc/pure-ftpd/pureftpd.passwd.tmp
```
* And get an error when trying to add a user.
```bash
$ sudo pure-pw useradd someuser -u 100 -g 80 -d /home/someuser/ -m
Password:
Enter it again:
Error.
Check that [someuser] doesn't already exist,
and that [/etc/pure-ftpd/pureftpd.passwd.tmp] can be written.
```

I think that it is enough to check the existence of the file and if it exists, then delete it.