### PR TITLE
Make --without-ascii fails

### DIFF
--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -3113,8 +3113,8 @@ static int dl_dowrite(DLHandler * const dlhandler, const unsigned char *buf_,
         *downloaded = 0;
         return -1;
     }
-    if (dlhandler->ascii_mode > 0) {
 #ifndef WITHOUT_ASCII
+    if (dlhandler->ascii_mode > 0) {
         unsigned char *asciibufpnt;
         size_t z = (size_t) 0U;
 


### PR DESCRIPTION
Make with `--without-ascii` fails due to invalid syntax. Just moved `#ifndef WITHOUT_ASCII` one line up.