### PR TITLE
Strip out runtime-options depending on build flags

### DIFF
--- a/src/ftpd_p.h
+++ b/src/ftpd_p.h
@@ -76,7 +76,7 @@ static const char *GETOPT_OPTIONS =
 #ifdef QUOTAS
     "n:"
 #endif
-#if defined(WITH_UPLOAD_SCRIPT)
+#ifdef WITH_UPLOAD_SCRIPT
     "o"
 #endif
 #ifdef WITH_ALTLOG
@@ -93,7 +93,11 @@ static const char *GETOPT_OPTIONS =
 #ifdef THROTTLING
     "t:T:"
 #endif
-    "u:U:V:wWxX"
+    "u:U:"
+#ifdef WITH_VIRTUAL_HOSTS
+    "V:"
+#endif
+    "wWxX"
 #ifdef WITH_OSX_BONJOUR
     "v:"
 #endif
@@ -109,31 +113,31 @@ static const char *GETOPT_OPTIONS =
 static struct option long_options[] = {
     { "notruncate", 0, NULL, '0' },
     { "logpid", 0, NULL, '1' },
-# ifdef WITH_TLS
+#ifdef WITH_TLS
     { "certfile", 1, NULL, '2' },
     { "extcert", 1, NULL, '3' },
-# endif
+#endif
     { "ipv4only", 0, NULL, '4' },
     { "ipv6only", 0, NULL, '6' },
     { "chrooteveryone", 0, NULL, 'A' },
     { "trustedgid", 1, NULL, 'a' },
     { "brokenclientscompatibility", 0, NULL, 'b' },
-# ifndef NO_STANDALONE
+#ifndef NO_STANDALONE
     { "daemonize", 0, NULL, 'B' },
     { "maxclientsperip", 1, NULL, 'C' },
-# endif
+#endif
     { "maxclientsnumber", 1, NULL, 'c' },
     { "verboselog", 0, NULL, 'd' },
     { "displaydotfiles", 0, NULL, 'D' },
     { "anonymousonly", 0, NULL, 'e' },
     { "noanonymous", 0, NULL, 'E' },
     { "syslogfacility", 1, NULL, 'f' },
-# ifdef COOKIE
+#ifdef COOKIE
     { "fortunesfile", 1, NULL, 'F' },
-# endif
-# ifndef NO_STANDALONE
+#endif
+#ifndef NO_STANDALONE
     { "pidfile", 1, NULL, 'g' },
-# endif
+#endif
     { "norename", 0, NULL, 'G' },
     { "help", 0, NULL, 'h' },
     { "dontresolve", 0, NULL, 'H' },
@@ -147,32 +151,36 @@ static struct option long_options[] = {
     { "anonymouscancreatedirs", 0, NULL, 'M' },
     { "maxload", 1, NULL, 'm' },
     { "natmode", 0, NULL, 'N' },
-# ifdef QUOTAS
+#ifdef QUOTAS
     { "quota", 1, NULL, 'n' },
-# endif
-# if defined(WITH_UPLOAD_SCRIPT)
+#endif
+#ifdef WITH_UPLOAD_SCRIPT
     { "uploadscript", 0, NULL, 'o' },
-# endif
-# ifdef WITH_ALTLOG
+#endif
+#ifdef WITH_ALTLOG
     { "altlog", 1, NULL, 'O' },
-# endif
+#endif
     { "passiveportrange", 1, NULL, 'p' },
     { "forcepassiveip", 1, NULL, 'P' },
-# ifdef RATIOS
+#ifdef RATIOS
     { "anonymousratio", 1, NULL, 'q' },
     { "userratio", 1, NULL, 'Q' },
-# endif
+#endif
     { "autorename", 0, NULL, 'r' },
     { "nochmod", 0, NULL, 'R' },
     { "antiwarez", 0, NULL, 's' },
-# ifndef NO_STANDALONE
+#ifndef NO_STANDALONE
     { "bind", 1, NULL, 'S' },
-# endif
+#endif
+#ifdef THROTTLING
     { "anonymousbandwidth", 1, NULL, 't' },
     { "userbandwidth", 1, NULL, 'T' },
+#endif
     { "umask", 1, NULL, 'U' },
     { "minuid", 1, NULL, 'u' },
+#ifdef WITH_VIRTUAL_HOSTS
     { "trustedip", 1, NULL, 'V' },
+#endif
 #ifdef WITH_OSX_BONJOUR
     { "bonjour", 1, NULL, 'v' },
 #endif
@@ -180,13 +188,13 @@ static struct option long_options[] = {
     { "allowanonymousfxp", 0, NULL, 'W' },
     { "prohibitdotfileswrite", 0, NULL, 'x' },
     { "prohibitdotfilesread", 0, NULL, 'X' },
-# ifdef PER_USER_LIMITS
+#ifdef PER_USER_LIMITS
     { "peruserlimits", 1, NULL, 'y' },
-# endif
-# ifdef WITH_TLS
+#endif
+#ifdef WITH_TLS
     { "tls", 1, NULL, 'Y' },
     { "tlsciphersuite", 1, NULL, 'J' },
-# endif
+#endif
     { "allowdotfiles", 0, NULL, 'z' },
     { "customerproof", 0, NULL, 'Z' },
     { NULL, 0, NULL, 0 }

--- a/src/simpleconf_ftpd.h
+++ b/src/simpleconf_ftpd.h
@@ -7,42 +7,75 @@ static const SimpleConfEntry simpleconf_options[] = {
     {"AllowAnonymousFXP? <bool>",                 "--allowanonymousfxp"},
     {"AllowDotFiles? <bool>",                     "--allowdotfiles"},
     {"AllowUserFXP? <bool>",                      "--allowuserfxp"},
+#ifdef WITH_ALTLOG
     {"AltLog (<any*>)",                           "--altlog=$0"},
+#endif
+#ifdef THROTTLING
     {"AnonymousBandwidth (<digits>) (<digits>)",  "--anonymousbandwidth=$0:$1"},
     {"AnonymousBandwidth (<digits>)",             "--anonymousbandwidth=$0"},
+#endif
     {"AnonymousCanCreateDirs? <bool>",            "--anonymouscancreatedirs"},
     {"AnonymousCantUpload? <bool>",               "--anonymouscantupload"},
     {"AnonymousOnly? <bool>",                     "--anonymousonly"},
+#ifdef RATIOS
     {"AnonymousRatio (<digits>) (<digits>)",      "--anonymousratio=$0:$1"},
+#endif
     {"AntiWarez? <bool>",                         "--antiwarez"},
     {"AutoRename? <bool>",                        "--autorename"},
+#ifndef NO_STANDALONE
     {"Bind (<nospace>)",                          "--bind=$0"},
+#endif
+#ifdef WITH_OSX_BONJOUR
+    {"Bonjour (<nospace>)",                       "--bonjour=$0"},
+#endif
     {"BrokenClientsCompatibility? <bool>",        "--brokenclientscompatibility"},
+#ifdef WITH_TLS
     {"CertFileAndKey (<any>) (<any>)",            "--certfile=$0,$1"},
     {"CertFile (<any*>)",                         "--certfile=$0"},
+#endif
     {"ChrootEveryone? <bool>",                    "--chrooteveryone"},
     {"CreateHomeDir? <bool>",                     "--createhomedir"},
     {"CustomerProof? <bool>",                     "--customerproof"},
+#ifndef NO_STANDALONE
     {"Daemonize? <bool>",                         "--daemonize"},
+#endif
     {"DisplayDotFiles? <bool>",                   "--displaydotfiles"},
     {"DontResolve? <bool>",                       "--dontresolve"},
+#ifdef WITH_TLS
     {"ExtCert (<any*>)",                          "--extcert=$0"},
+#endif
     {"ForcePassiveIP (<nospace>)",                "--forcepassiveip=$0"},
+#ifdef COOKIE
     {"FortunesFile (<any*>)",                     "--fortunesfile=$0"},
+#endif
     {"IPV4Only? <bool>",                          "--ipv4only"},
     {"IPV6Only? <bool>",                          "--ipv6only"},
     {"KeepAllFiles? <bool>",                      "--keepallfiles"},
     {"LimitRecursion (<digits>) (<digits>)",      "--limitrecursion=$0:$1"},
+#ifdef WITH_EXTAUTH
     {"ExtAuth (<any*>)",                          "--login=extauth:$0"},
+#endif
+#ifdef WITH_LDAP
     {"LDAPConfigFile (<any*>)",                   "--login=ldap:$0"},
+#endif
+#ifdef WITH_MYSQL
     {"MySQLConfigFile (<any*>)",                  "--login=mysql:$0"},
+#endif
+#ifdef USE_PAM
     {"PAMAuthentication? <bool>",                 "--login=pam"},
+#endif
+#ifdef WITH_PGSQL
     {"PGSQLConfigFile (<any*>)",                  "--login=pgsql:$0"},
+#endif
+#ifdef WITH_PUREDB
     {"PureDB (<any*>)",                           "--login=puredb:$0"},
+#endif
     {"UnixAuthentication? <bool>",                "--login=unix"},
     {"LogPID? <bool>",                            "--logpid"},
     {"MaxClientsNumber (<digits>)",               "--maxclientsnumber=$0"},
+#ifndef NO_STANDALONE
     {"MaxClientsPerIP (<digits>)",                "--maxclientsperip=$0"},
+#endif
     {"MaxDiskUsage (<digits>)",                   "--maxdiskusagepct=$0"},
     {"MaxIdleTime (<digits>)",                    "--maxidletime=$0"},
     {"MaxLoad (<digits>)",                        "--maxload=$0"},
@@ -53,21 +86,37 @@ static const SimpleConfEntry simpleconf_options[] = {
     {"NoRename? <bool>",                          "--norename"},
     {"NoTruncate? <bool>",                        "--notruncate"},
     {"PassivePortRange (<digits>) (<digits>)",    "--passiveportrange=$0:$1"},
+#ifdef PER_USER_LIMITS
     {"PerUserLimits (<digits>):(<digits>)",       "--peruserlimits=$0:$1"},
+#endif
+#ifndef NO_STANDALONE
     {"PIDFile (<any*>)",                          "--pidfile=$0"},
+#endif
     {"ProhibitDotFilesWrite? <bool>",             "--prohibitdotfileswrite"},
     {"ProhibitDotFilesRead? <bool>",              "--prohibitdotfilesread"},
+#ifdef QUOTAS
     {"Quota (<digits>):(<digits>)",               "--quota=$0:$1"},
+#endif
     {"SyslogFacility (<alnum>)",                  "--syslogfacility=$0"},
-    {"TLSCipherSuite (<nospace>)",                "--tlsciphersuite=$0"},
+#ifdef WITH_TLS
     {"TLS (<digits>)",                            "--tls=$0"},
+    {"TLSCipherSuite (<nospace>)",                "--tlsciphersuite=$0"},
+#endif
     {"TrustedGID (<digits>)",                     "--trustedgid=$0"},
+#ifdef WITH_VIRTUAL_HOSTS
     {"TrustedIP (<nospace>)",                     "--trustedip=$0"},
+#endif
     {"Umask (<digits>):(<digits>)",               "--umask=$0:$1"},
+#ifdef WITH_UPLOAD_SCRIPT
     {"CallUploadScript? <bool>",                  "--uploadscript"},
+#endif
+#ifdef THROTTLING
     {"UserBandwidth (<digits>) (<digits>)",       "--userbandwidth=$0:$1"},
     {"UserBandwidth (<digits>)",                  "--userbandwidth=$0"},
+#endif
+#ifdef RATIOS
     {"UserRatio (<digits>) (<digits>)",           "--userratio=$0:$1"},
+#endif
     {"VerboseLog? <bool>",                        "--verboselog"}
 };
 


### PR DESCRIPTION
I had some trouble to identify unsupported runtime-options, when using a configuration file, which did not match with the build-flags.
For example: I set `UserBandwidth  123` within `pure-ftpd.conf`, but build was done without `./configure --with-throttling`. When starting the server only `421 Unknown run-time option` comes up, not naming unknown option.

* Support for "Bonjour"-runtime-option added to configuration file.
* Strip out runtime-options for command-line **and** configuration file depending on build flags.