### PR TITLE
Order of configuration runtime-option matters

### DIFF
--- a/src/simpleconf_ftpd.h
+++ b/src/simpleconf_ftpd.h
@@ -99,8 +99,8 @@ static const SimpleConfEntry simpleconf_options[] = {
 #endif
     {"SyslogFacility (<alnum>)",                  "--syslogfacility=$0"},
 #ifdef WITH_TLS
-    {"TLS (<digits>)",                            "--tls=$0"},
     {"TLSCipherSuite (<nospace>)",                "--tlsciphersuite=$0"},
+    {"TLS (<digits>)",                            "--tls=$0"},
 #endif
     {"TrustedGID (<digits>)",                     "--trustedgid=$0"},
 #ifdef WITH_VIRTUAL_HOSTS


### PR DESCRIPTION
I'm very sorry, I introduced this bug. The order of long runtime-option matters! Having `TLS` defined before ` TLSCipherSuite` will result in `syntax error line 123: [CipherSuite HIGH].` at server startup; obviously the "TLS" prefix gets cutted.