### PR TITLE
fix the maxfile_size checking bug

### DIFF
--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -4247,8 +4247,8 @@ void dostor(char *name, const int append, const int autorename)
     if (quota_update(&quota, 0LL, 0LL, &overflow) == 0 &&
         (overflow > 0 || quota.files >= user_quota_files ||
          quota.size > user_quota_size ||
-         (max_filesize >= (off_t) 0 &&
-          (max_filesize = user_quota_size - quota.size) < (off_t) 0))) {
+         ((max_filesize = user_quota_size - quota.size) < (off_t) 0 &&
+          max_filesize >= (off_t) 0))) {
         overflow = 1;
         (void) close(f);
         goto afterquota;


### PR DESCRIPTION
Fix the predicate that never evaluates true.

Hi,

I occasionally found the PureFTPd continues to receive a file when user quota is exceeded. My debugging shows that the following predicates never evaluate true, since max_filesize =-1 initially:

(max_filesize >= (off_t) 0 &&
          (max_filesize = user_quota_size - quota.size) < (off_t) 0)

When max_filesize >=(off_t) 0 evaluates false, the followed predicate will not be evaluated. Hence max_filesize =-1 for ever. This bug leads to that there is no overflow even if quota is exceeded. 

For a simple patch, I changed the order of these two predicates such that max_filesize = user_quota_size - quota.size) < (off_t) 0 is evaluated first, then max_filesize will be assigned with the actual quota. Then quota will be checked correctly. 

Bests
Joy


   