### PR TITLE
Define escaped_port in pw_pgsql_connect()

### DIFF
--- a/src/log_pgsql.c
+++ b/src/log_pgsql.c
@@ -269,6 +269,7 @@ static int pw_pgsql_connect(PGconn ** const id_sql_server)
     char *conninfo = NULL;
     size_t sizeof_conninfo;
     char *escaped_server = NULL;
+    char *escaped_port = NULL;
     char *escaped_db = NULL;
     char *escaped_user = NULL;
     char *escaped_pw = NULL;
@@ -277,6 +278,7 @@ static int pw_pgsql_connect(PGconn ** const id_sql_server)
     *id_sql_server = NULL;
 
     if ((escaped_server = pw_pgsql_escape_conninfo(server)) == NULL ||
+        (escaped_port = pw_pgsql_escape_conninfo(port)) == NULL ||
         (escaped_db = pw_pgsql_escape_conninfo(db)) == NULL ||
         (escaped_user = pw_pgsql_escape_conninfo(user)) == NULL ||
         (escaped_pw = pw_pgsql_escape_conninfo(pw)) == NULL) {
@@ -312,6 +314,7 @@ static int pw_pgsql_connect(PGconn ** const id_sql_server)
     bye:
     free(conninfo);
     free(escaped_server);
+    free(escaped_port);
     free(escaped_db);
     free(escaped_user);
     free(escaped_pw);


### PR DESCRIPTION
This patch declares ```escaped_port``` within ```pw_pgscl_connect()``` in ```src/log_pgsql.c```,  and fixes the following compilation issue:

```
CC       libpureftpd_a-log_pgsql.o
In file included from ftpd.h:109:0,
                 from log_pgsql.c:7:
log_pgsql.c: In function ‘pw_pgsql_connect’:
log_pgsql.c:297:42: error: ‘escaped_port’ undeclared (first use in this function)
                          escaped_server, escaped_port, escaped_db,
```
