### PR TITLE
Clean up unused variable

### DIFF
--- a/src/log_pgsql.c
+++ b/src/log_pgsql.c
@@ -269,7 +269,6 @@ static int pw_pgsql_connect(PGconn ** const id_sql_server)
     char *conninfo = NULL;
     size_t sizeof_conninfo;
     char *escaped_server = NULL;
-    char *escaped_port = NULL;
     char *escaped_db = NULL;
     char *escaped_user = NULL;
     char *escaped_pw = NULL;


### PR DESCRIPTION
escaped_port is no longer needed after c3f0f3c91d86939e6fabf5f65c6c6fc964e6032e.