### PR TITLE
Allow QUIT during an active transfer to defer until transfer completes

### DIFF
--- a/src/ftp_parser.c
+++ b/src/ftp_parser.c
@@ -247,6 +247,12 @@ void parser(void)
             }
 #endif
         }
+        if (deferred_quit != 0) {
+            addreply(221, MSG_GOODBYE,
+                     (unsigned long long) ((uploaded + 1023ULL) / 1024ULL),
+                     (unsigned long long) ((downloaded + 1023ULL) / 1024ULL));
+            return;
+        }
         doreply();
         alarm(idletime * 2);
         switch (sfgets()) {

--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -3175,15 +3175,17 @@ static int dlhandler_handle_commands(DLHandler * const dlhandler,
         buf[readnb] = 0;
         bufpnt = skip_telnet_controls(buf);
         if (strchr(bufpnt, '\n') != NULL) {
-            if (strncasecmp(bufpnt, "ABOR", sizeof "ABOR" - 1U) != 0 &&
-                strncasecmp(bufpnt, "QUIT", sizeof "QUIT" - 1U) != 0) {
-                addreply_noformat(500, MSG_UNKNOWN_COMMAND);
-                doreply();
-            } else {
+            if (strncasecmp(bufpnt, "ABOR", sizeof "ABOR" - 1U) == 0) {
                 addreply_noformat(426, "ABORT");
                 doreply();
                 addreply_noformat(226, MSG_ABORTED);
                 return 1;
+            } else if (strncasecmp(bufpnt, "QUIT", sizeof "QUIT" - 1U) == 0) {
+                deferred_quit = 1;
+                logfile(LOG_DEBUG, "Deferring QUIT until dl completes.");
+            } else {
+                addreply_noformat(500, MSG_UNKNOWN_COMMAND);
+                doreply();
             }
         }
         if (required_sleep > 0.0) {
@@ -3901,14 +3903,16 @@ static int ulhandler_handle_commands(ULHandler * const ulhandler)
     buf[readnb] = 0;
     bufpnt = skip_telnet_controls(buf);
     if (strchr(buf, '\n') != NULL) {
-        if (strncasecmp(bufpnt, "ABOR", sizeof "ABOR" - 1U) != 0 &&
-            strncasecmp(bufpnt, "QUIT", sizeof "QUIT" - 1U) != 0) {
-            addreply_noformat(500, MSG_UNKNOWN_COMMAND);
-            doreply();
-        } else {
+        if (strncasecmp(bufpnt, "ABOR", sizeof "ABOR" - 1U) == 0) {
             addreply_noformat(426, MSG_ABORTED);
             doreply();
             return 1;
+        } else if (strncasecmp(bufpnt, "QUIT", sizeof "QUIT" - 1U) == 0) {
+            deferred_quit = 1;
+            logfile(LOG_DEBUG, "Deferring QUIT until ul completes.");
+        } else {
+            addreply_noformat(500, MSG_UNKNOWN_COMMAND);
+            doreply();
         }
     }
     return 0;

--- a/src/globals.h
+++ b/src/globals.h
@@ -80,6 +80,7 @@ GLOBAL(unsigned int max_ls_depth, DEFAULT_MAX_LS_DEPTH);
 GLOBAL0(char *fortunes_file);
 GLOBAL0(char host[NI_MAXHOST]);
 GLOBAL0(int replycode);
+GLOBAL(char deferred_quit, 0);
 GLOBAL0(signed char force_ls_a);
 GLOBAL0(struct sockaddr_storage peer);
 GLOBAL0(struct sockaddr_storage force_passive_ip);


### PR DESCRIPTION
I'm not sure if this is the ideal way to fix this issue, if it introduces other issues, or if the current behaviour is preferred by the developers. 

The problem I am having is with blackbox firmware (Cisco IOS and other network vendors) pushing config to an FTP and expecting command pipelining to delay a QUIT until data transfers complete. They are simple clients that just blast commands and wait for sockets to close. Looking at RFC959, this is probably expected behaviour - it's not precisely stated. With current pure-ftpd, this results in aborting mid-transfer and truncated uploads. 

My assumption on the RFC appears to be matched by a few other FTP daemons I checked (vsftpd, proftpd and pyftpdlib), only pure-ftpd treated a QUIT like an immediate ABOR. 

This fix delays the reaction to a QUIT until all data transfers complete (an ABOR will still kill a transfer as expected), plus it will actually react like a QUIT and cleanup immediately on return to the parser loop, rather than waiting for the client to disconnect. 

I've done some one-shot testing of this workaround patch against netkit ftp, ncftp, python 3.10 ftplib, winscp and the problem devices without issue.