### PR TITLE
BrokenClientsCompatibility mode disables EPSV

### DIFF
--- a/README
+++ b/README
@@ -647,7 +647,7 @@ group. '-A' and '-a <gid>' are mutually exclusive.
 
 - '-b': Ignore parts of RFC standards in order to deal with some totally
 broken FTP clients, or broken firewalls/NAT boxes. Also, non-dangling
-symbolic links are shown as real files/directories. Also, EPSV is disabled.
+symbolic links are shown as real files/directories. EPSV is disabled.
 
 - '-B': Have the standalone server start in background (daemonization).
 

--- a/README
+++ b/README
@@ -647,7 +647,7 @@ group. '-A' and '-a <gid>' are mutually exclusive.
 
 - '-b': Ignore parts of RFC standards in order to deal with some totally
 broken FTP clients, or broken firewalls/NAT boxes. Also, non-dangling
-symbolic links are shown as real files/directories.
+symbolic links are shown as real files/directories. Also, EPSV is disabled.
 
 - '-B': Have the standalone server start in background (daemonization).
 


### PR DESCRIPTION
I spent a bit of time scratching my head when my server kept saying "unknown command", so let's update the doc with a note.  I'd be glad to update the man page as well. 

Source: Frank via https://marc.info/?l=pureftpd-list&m=126044538824016&w=2