### PR TITLE
configure.ac: Silence harmless -Wimplicit-function-declaration warnin…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -718,6 +718,9 @@ AC_MSG_CHECKING([if a hpuxish sendfile is available])
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #include <sys/socket.h>
 #include <stdio.h>
+#ifdef HAVE_SYS_SENDFILE_H
+# include <sys/sendfile.h>
+#endif
 ]], [[
 do {
  int fd = 0;


### PR DESCRIPTION
…g in hpux sendfile check

We're currently looking for build systems where -Wimplicit-function-declaration is emitted by checks as it often implies a missing include, but in this case, it's fine - HPUX doesn't have a sendfile header, so it's just noise (and it won't be true on Linux anyway).

But the check is run unconditionally and we already check if sendfile.h exists, so include the header conditionally if it exists, as it's harmless and it avoids it looking like there's a problem in pure-ftpd.

Unfortunately, it's not so easy to silence the sendfilev check which has a similar (but different) problem because it uses AC_CHECK_FUNCS.

Bug: https://bugs.gentoo.org/900068