### PR TITLE
Remove nonroot part from logfile

### DIFF
--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -602,10 +602,6 @@ static int generic_aton(const char *src, struct sockaddr_storage *a)
 
 void logfile(const int crit, const char *format, ...)
 {
-#if defined(NON_ROOT_FTP)
-    (void) crit;
-    (void) format;
-#else
     const char *urgency;
     va_list va;
     char line[MAX_SYSLOG_LINE];
@@ -646,7 +642,6 @@ void logfile(const int crit, const char *format, ...)
 # ifdef SAVE_DESCRIPTORS
     closelog();
 # endif
-#endif
 }
 
 #ifndef NO_STANDALONE


### PR DESCRIPTION
pure-ftpd log nothing if it was built with `--with-nonroot` flag. Without these lines it log messages into syslog and works properly.
Don't know if I break anything with these changes, I guess in the past only root could write to syslog but since this is not the deal anymore this protection not necessary.