### PR TITLE
Remove O_NOFOLLOW on opening of quota file

### DIFF
--- a/src/pure-quotacheck.c
+++ b/src/pure-quotacheck.c
@@ -239,7 +239,7 @@ static int writequota(const char * const quota_file)
         (void) fchmod(fd, st.st_mode | 0700);
     }
     close(fd);
-    if ((fd = open(quota_file, O_RDWR | O_CREAT | O_NOFOLLOW,
+    if ((fd = open(quota_file, O_RDWR | O_CREAT,
                    (mode_t) 0600)) == -1) {
         return -1;
     }

--- a/src/quotas.c
+++ b/src/quotas.c
@@ -51,7 +51,7 @@ int quota_update(Quota *quota,
     }
     *overflow = 0;
     *quota = old_quota;
-    if ((fd = open("/" QUOTA_FILE, O_RDWR | O_CREAT | O_NOFOLLOW,
+    if ((fd = open("/" QUOTA_FILE, O_RDWR | O_CREAT,
                    (mode_t) 0600)) == -1) {
         return -1;
     }


### PR DESCRIPTION
There is no need to use O_NOFOLLOW. Since .ftpquota is a reserved name for pure-ftpd. We would like to use symlinks for shared quotas across multiple users. Therefore, I am sending a request for a small update :-).