### PR TITLE
fix: server sending "227 Logout." response

### DIFF
--- a/src/ftp_parser.c
+++ b/src/ftp_parser.c
@@ -263,7 +263,7 @@ void parser(void)
             die(421, LOG_INFO, MSG_TIMEOUT_PARSER);
 #endif
         case -2:
-            return;
+            die(425, LOG_INFO, MSG_LOGOUT);
         }
 #ifdef DEBUG
         if (debug != 0) {


### PR DESCRIPTION
Hi, I recently ran into an issue with data connection in passive mode (I'm not sure if it couldn't be established or if it was interrupted), which caused the server to send "227 Logout." response.

However this response was being blocked by Linux's netfiter connection tracking FTP helper because it couldn't find a port number. This caused both sides to get stucked in unusual state (Client was stucked in `FIN-WAIT-1` and server in `LAST-ACK`).
This also printed dozens of messages like this into kernel log:

```
nf_ct_ftp: dropping packet: partial matching of `227 ' IN= OUT= SRC=192.168.88.11 DST=192.168.88.2 LEN=65 TOS=0x10 PREC=0x00 TTL=64 ID=21753 DF PROTO=TCP SPT=21 DPT=52558 SEQ=1495310752 ACK=1151444886 WINDOW=1019 RES=0x00 ACK PSH FIN URGP=0 OPT (0101080ACEAB6C79379C8674) 
nf_ct_ftp: dropping packet: partial matching of `227 ' IN= OUT= SRC=192.168.88.11 DST=192.168.88.2 LEN=77 TOS=0x10 PREC=0x00 TTL=64 ID=10135 DF PROTO=TCP SPT=21 DPT=41954 SEQ=2017135651 ACK=1446358301 WINDOW=1019 RES=0x00 ACK PSH FIN URGP=0 OPT (0101080ACEAB904E379D83CA0101050A5635AD1C5635AD1D) 
nf_ct_ftp: dropping packet: partial matching of `227 ' IN= OUT= SRC=192.168.88.11 DST=192.168.88.2 LEN=65 TOS=0x10 PREC=0x00 TTL=64 ID=10136 DF PROTO=TCP SPT=21 DPT=41954 SEQ=2017135651 ACK=1446358301 WINDOW=1019 RES=0x00 ACK PSH FIN URGP=0 OPT (0101080ACEAB9127379D83CA)
```

Some details on how to reproduce this issue are here https://github.com/NICMx/Jool/issues/425