### PR TITLE
fix a bug of out-of-bounds reading in the domlsd() function in the ls.c

### DIFF
--- a/src/ls.c
+++ b/src/ls.c
@@ -1051,8 +1051,8 @@ void domlsd(const char *base)
 
     if (*base != 0 && chdir(base) != 0) {
         if (*base++ == '-') {
-            while (!isspace((unsigned char) *base++));
-            while (isspace((unsigned char) *base++));
+            while (*base!=0 && !isspace((unsigned char) *base++));
+            while (*base!=0 && isspace((unsigned char) *base++));
             if (*base != 0 && chdir(base) != 0) {
                 addreply_noformat(550, MSG_STAT_FAILURE2);
                 return;


### PR DESCRIPTION
In the domlsd() function of the ls.c file, this code: `!isspace((unsigned char) * base++)` does not check if the base pointer points to the end of the cmd buffer, so this error may cause the base pointer to cross the cmd buffer, resulting in out-of-bounds read errors.
There are POC scripts below that can cause out-of-bounds reads:

```python
from pwn import *
import sys
ip=sys.argv[1]
port=sys.argv[2]
p=remote(ip,port)
# authentication
p.sendline(b"USER fuzzing")
p.sendline(b"PASS fuzzing")
#sending payload triggers the bug
payload=b"MLSD -".ljust(4110,b'.')
p.sendline(payload)
p.interactive()
```
The following image shows the base pointer before triggering the vulnerability, which points to the cmd buffer:
![before](https://github.com/user-attachments/assets/4a75345b-e502-4086-b701-16abf3a1d500)

After executing the vulnerability point, the base pointer crosses the cmd buffer and points to other buffers, as shown in the following figure:
![after](https://github.com/user-attachments/assets/9226e128-9493-4a4d-90b7-245b9579f911)

