### PR TITLE
Add support and documentation for "ldapi://"  URI scheme

### DIFF
--- a/README.LDAP
+++ b/README.LDAP
@@ -68,9 +68,13 @@ details anyway:
 
 - LDAPScheme is the scheme (aka protocol) to connect with to the LDAP server.
 It defaults to 'ldap'. To connect to a server listening on TLS port, set it
-to 'ldaps' (and change the port below).
+to 'ldaps' (and change the port below).  To connect to a server listening on 
+a Unix domain socket, set it to 'ldapi'
 
 - LDAPServer is the LDAP server name (hey!) . It defaults to 'localhost'.
+If the 'ldapi' scheme is in use, this field should be set to the
+*URL-encoded* path of the server socket. For example,
+'/var/run/ldap.sock' becomes '%2Fvar%2Frun%2Fldap.sock'.
 
 - LDAPPort is the connection port. It defaults to 389, the standard port.
 Port value should be changed for 'ldaps' connection (the TLS port for an

--- a/src/log_ldap.c
+++ b/src/log_ldap.c
@@ -125,9 +125,17 @@ illegal_config:
         if ((ldap_uri = malloc(sizeof_ldap_uri)) == NULL) {
             die_mem();
         }
-        snprintf(ldap_uri, sizeof_ldap_uri, "%s%s%s%s%s%d",
-                 ldap_scheme, URI_SCHEME_SEPARATOR, URI_AUTHORITY_LEADER,
-                 ldap_host, URI_PORT_LEADER, port);
+
+        /* The "ldapi://" scheme uri cannot contain a port number*/
+        if (pure_strcmp(ldap_scheme, "ldapi") == 0) {
+                snprintf(ldap_uri, sizeof_ldap_uri, "%s%s%s%s",
+                         ldap_scheme, URI_SCHEME_SEPARATOR, URI_AUTHORITY_LEADER,
+                         ldap_host);
+        } else {
+                snprintf(ldap_uri, sizeof_ldap_uri, "%s%s%s%s%s%d",
+                         ldap_scheme, URI_SCHEME_SEPARATOR, URI_AUTHORITY_LEADER,
+                         ldap_host, URI_PORT_LEADER, port);
+	}
     }
 
     /* Default to auth method bind, but for backward compatibility, if a binddn


### PR DESCRIPTION
The existing LDAP code allows an administrator to select the URI scheme used to connect to the LDAP server: either "ldap://" or "ldaps://".  However there exists an additional scheme "ldapi://" which was created by the authors of OpenLDAP ([See Here](https://datatracker.ietf.org/doc/html/draft-chu-ldap-ldapi)).  This allows a URI to be constructed that specifies a Unix domain socket to connect to on the filesystem.  

Coincidentally, the LDAP client library which pure-ftpd uses is libldap which is part of the OpenLDAP project.  The existing pure-ftpd LDAP code simply constructs an LDAP URI string and passes it directly to this library.  This _almost_ allows pure-ftpd servers to use the ldapi scheme as-is, but the existing code always appends a port number to the URI and ldapi URIs cannot have port numbers.

This trivial patch simply checks the provided LDAPScheme to see if it is "ldapi" and then omits the port number from the generated URI string.  It also adds some documentation to indicate that ldapi URIs will work.

I have been using this patch for a while now and thought it might be worth giving back.  Since ldapi URIs are a bit odd, I will provide the first two lines of my actual pure-ftpd.d/ldap.conf file as an example:
```
LDAPScheme ldapi
LDAPServer %2Frun%2Fopenldap%2Fslapd.socket
```