### PR TITLE
support active directory

### DIFF
--- a/src/log_ldap.c
+++ b/src/log_ldap.c
@@ -555,7 +555,7 @@ void pw_ldap_check(AuthResult * const result,
         int ok = 0;
 
         /* Verify password by binding to LDAP */
-        if (password != NULL && *password != 0 &&
+        if (password != NULL && *password != 0 && *dn != 0 &&
             (ld = pw_ldap_connect(dn, password)) != NULL) {
             ldap_unbind(ld);
             ok = 1;


### PR DESCRIPTION
*dn is '\0' if user not found and pw_ldap_connect will succeed when connect to active directory even dn is '\0'.
Should fail if user not found.