### PR TITLE
Feat: Allow a pam module to switch user using RUSER

### DIFF
--- a/src/log_pam.c
+++ b/src/log_pam.c
@@ -151,6 +151,8 @@ void pw_pam_check(AuthResult * const result,
                   const struct sockaddr_storage * const peer)
 {
     pam_handle_t *pamh;
+    const char *newusername;
+    int retval;
     int pam_error;
     struct passwd pw, *pw_;
     char *dir = NULL;
@@ -187,6 +189,12 @@ void pw_pam_check(AuthResult * const result,
     PAM_BAIL;
     pam_error = pam_acct_mgmt(pamh, 0);
     PAM_BAIL;
+    /* A PAM module might have changed the username (alias) */
+    retval = pam_get_item(pamh, PAM_RUSER, (const void **)&newusername);
+    if (retval == PAM_SUCCESS && newusername != NULL)
+    {
+        user = newusername;
+    }
     /* If this point is reached, the user has been authenticated. */
     if ((pw_ = getpwnam(user)) == NULL) {
         goto bye;


### PR DESCRIPTION
This PR brings a new feature into the pure-ftpd PAM connector.

A PAM module might changed the username used. In case of an alias for example.
Currently we ignore this and still use the username provided during the authentication dialog.

This patch allows to do so based on the RUSER pam variable : 
- PAM_USER : contains the username that initiated the login session
- PAM_RUSER : contains the real username that was authenticated