### PR TITLE
Systemd Integration

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,6 +35,7 @@ EXTRA_DIST = \
 	pureftpd-ldap.conf \
 	pureftpd-mysql.conf \
 	pureftpd-pgsql.conf \
+	pure-ftpd.service \
 	pureftpd.schema
 
 SUBDIRS = \

--- a/README
+++ b/README
@@ -120,6 +120,9 @@ option later in this documentation for additional info.
 implementation. If altlog and/or pure-uploadscript doesn't seem to work
 properly on your system, try to recompile with this switch.
 
+--with-systemd: Enables systemd integration on Linux (default=detect).
+See installation notes for systemd below for further info.
+
 --with-tls: enable TLS support. Read README.TLS for more about this feature.
 
 --with-certfile=<file>: the file with the TLS certificate (see README.TLS). The
@@ -553,6 +556,25 @@ tcpserver -DHRl0 0 21 /usr/local/bin/pure-ftpd &
 You can add that line to your system local startup scripts
 (usually /etc/rc.d/boot.local or /etc/rc.d/rc.local) . If it doesn't work,
 replace 'tcpserver' with its full path (eg. '/usr/local/bin/tcpserver') .
+
+
+  ------------------------ SYSTEMD INSTALLATION ------------------------
+
+
+On Linux the server can be integrated with systemd. The provided unit file
+must be copied to the systemd system unit dir manually (/lib/systemd/system/)
+and enabled with 'systemctl enable pure-ftpd.service'.
+The service will run under its own user account (pure-ftpd) with appropriate
+capabilities set in the unit file. The user has to be created manually.
+Capablities are required, unless to unit file is modified to run the server
+under root account (by removing the capabilites and user/group). Privilege
+separation is recommended.
+The server will start by default with configuration file /etc/pure-ftpd.conf
+This can be overridden by setting command line start options in
+/etc/systemd/pure-ftpd.conf as an environment variable named CONF=
+(CONF=/etc/alternate.conf or CONF="-4 -A -j ...").
+The daemonize option will be ignored when the server is started by systemd.
+Do NOT change Type=simple or NotifAccess= in the unit file.
 
 
           ------------------------ OPTIONS ------------------------

--- a/configure.ac
+++ b/configure.ac
@@ -124,7 +124,7 @@ AC_HEADER_DIRENT
 AC_HEADER_SYS_WAIT
 AC_CHECK_HEADERS(unistd.h string.h strings.h sys/param.h ioctl.h sys/ioctl.h)
 AC_CHECK_HEADERS(sys/vfs.h sys/statvfs.h sys/sendfile.h sys/uio.h)
-AC_CHECK_HEADERS(sys/time.h sys/resource.h sys/capability.h)
+AC_CHECK_HEADERS(sys/time.h sys/resource.h sys/capability.h systemd/sd-daemon.h)
 AC_CHECK_HEADERS(shadow.h getopt.h stddef.h stdint.h)
 AC_CHECK_HEADERS(netinet/in_systm.h netinet/in.h sys/pstat.h sys/file.h)
 AC_CHECK_HEADERS(sys/mount.h, [], [],
@@ -408,6 +408,21 @@ AC_ARG_WITH(privsep,
 [ if test "x$withval" = "xno" ; then
     without_privsep=yes
   fi ])
+
+AC_ARG_WITH(systemd,
+[AS_HELP_STRING(--with-systemd,Use Linux systemd (default=detect))],
+[ if test "x$withval" = "xno" ; then
+    no_systemd=1
+  fi ])
+
+if test -z "$no_systemd" ; then
+  AC_CHECK_LIB(systemd, sd_notify, , )
+  if test "x$ac_cv_lib_systemd_sd_notify" = "xyes"; then
+    if test "x$ac_cv_header_systemd_sd_daemon_h" = "xyes"; then
+      AC_DEFINE(USE_SYSTEMD,,[use systemd])
+    fi
+  fi
+fi
 
 AC_ARG_WITH(boring,
 [AS_HELP_STRING(--with-boring,Display only boring messages)],

--- a/pure-ftpd.service
+++ b/pure-ftpd.service
@@ -1,0 +1,37 @@
+[Unit]
+Description=Pure FTP Daemon
+After=network-online.target
+
+[Service]
+Type=simple
+User=pure-ftpd
+Group=pure-ftpd
+UMask=0027
+PermissionsStartOnly=True
+RuntimeDirectory=pure-ftpd
+RuntimeDirectoryMode=0775
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID CAP_SYS_CHROOT CAP_CHOWN CAP_SYS_NICE CAP_DAC_READ_SEARCH
+AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID CAP_SYS_CHROOT CAP_CHOWN CAP_SYS_NICE CAP_DAC_READ_SEARCH
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+ProtectHostname=true
+ProtectProc=noaccess
+ProcSubset=pid
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=true
+ProtectSystem=full
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+PrivateDevices=true
+PrivateTmp=true
+Environment=CONF=/etc/pure-ftpd.conf
+EnvironmentFile=-/etc/systemd/pure-ftpd.conf
+ExecStart=/usr/bin/pure-ftpd $CONF
+
+[Install]
+WantedBy=multi-user.target

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -122,6 +122,7 @@ libpureftpd_a_SOURCES = \
 	simpleconf_ftpd.h \
 	simpleconf.c \
 	syslognames.h \
+	systemd.h \
 	tls.h \
 	tls_extcert.h \
 	tls_extcert_p.h \

--- a/src/ftpd.c
+++ b/src/ftpd.c
@@ -8,6 +8,7 @@
 #include "ftpwho-read.h"
 #include "globals.h"
 #include "caps.h"
+#include "systemd.h"
 #include "alt_arc4random.h"
 #if defined(WITH_UPLOAD_SCRIPT)
 # include "upload-pipe.h"
@@ -361,6 +362,9 @@ void die(const int err, const int priority, const char * const format, ...)
     vsnprintf(line, sizeof line, format, va);
     addreply(err, "%s", line);
     va_end(va);
+#ifdef USE_SYSTEMD
+    sd_notifyf(0, "STOPPING=1\nSTATUS=%s\nMAINPID=%d", line, getpid());
+#endif
     doreply();
     logfile(priority, "%s", line);
     _EXIT(-priority - 1);
@@ -5374,6 +5378,8 @@ static void standalone_server(void)
     struct addrinfo hints, *res, *res6;
     fd_set rs;
     int max_fd;
+    struct timeval *timeout = NULL;
+    uint64_t nr_reqs = 0;
 
 # ifndef NO_INETD
     standalone = 1;
@@ -5466,13 +5472,23 @@ static void standalone_server(void)
         max_fd = listenfd6;
     }
     max_fd++;
+#ifdef USE_SYSTEMD
+    sd_notifyf(0, "READY=1\nSTATUS=Waiting for Connections\nMAINPID=%d", getpid());
+    sd_notify(0, "WATCHDOG=1");
+    sd_notify(0, "WATCHDOG_USEC=30000000");
+    timeout = &sd_notify_timeout;
+#endif
     while (stop_server == 0) {
         safe_fd_set(listenfd, &rs);
         safe_fd_set(listenfd6, &rs);
-        if (select(max_fd, &rs, NULL, NULL, NULL) <= 0) {
+        if (select(max_fd, &rs, NULL, NULL, timeout) <= 0) {
             if (errno != EINTR) {
                 (void) sleep(1);
             }
+#ifdef USE_SYSTEMD
+            sd_notify(0, "WATCHDOG=1");
+            sd_notify_timeout = (struct timeval){ 10, 0 };
+#endif
             continue;
         }
         if (safe_fd_isset(listenfd, &rs)) {
@@ -5481,7 +5497,12 @@ static void standalone_server(void)
         if (safe_fd_isset(listenfd6, &rs)) {
             accept_client(listenfd6);
         }
+#ifdef USE_SYSTEMD
+        nr_reqs++;
+        sd_notifyf(0, "STATUS=Processed %lu Connection%s\nMAINPID=%d", nr_reqs, nr_reqs == 1 ? "" : "s", getpid());
+#endif
     }
+    sd_notifyf(0, "STOPPING=1\nSTATUS=Pure FTPd Shutting Down\nMAINPID=%d", getpid());
 }
 #endif
 
@@ -5563,9 +5584,13 @@ int pureftpd_start(int argc, char *argv[], const char *home_directory_)
     openlog("pure-ftpd", LOG_NDELAY | log_pid, DEFAULT_FACILITY);
 #endif
 
+#ifdef USE_SYSTEMD
+    sd_notifyf(0, "STATUS=Starting Pure FTPd\nMAINPID=%d", getpid());
+#endif
 #ifdef USE_CAPABILITIES
     set_initial_caps();
 #endif
+
     set_signals();
 
     loggedin = 0;
@@ -6235,7 +6260,12 @@ int pureftpd_start(int argc, char *argv[], const char *home_directory_)
         first_authentications->next = NULL;
     }
 #ifndef NO_STANDALONE
-    dodaemonize();
+  #ifdef USE_SYSTEMD
+    // Do not daemonize when started by systemd.
+    systemd_init = sd_booted() > 0 && (getppid() == 1 || getenv("NOTIFY_SOCKET"));
+  #endif
+    if (systemd_init == 0)
+        dodaemonize();
 #endif
 #ifndef SAVE_DESCRIPTORS
     if (no_syslog == 0 && (log_pid || syslog_facility != DEFAULT_FACILITY)) {

--- a/src/systemd.h
+++ b/src/systemd.h
@@ -1,0 +1,10 @@
+#ifndef __SYSTEMD_H__
+#define __SYSTEMD_H__ 1
+
+int systemd_init = 0;
+struct timeval sd_notify_timeout = { 10, 0 };
+#ifdef USE_SYSTEMD
+#include <systemd/sd-daemon.h>
+#endif
+
+#endif


### PR DESCRIPTION
This commit enables systemd integration on Linux.
 - configure.ac and Makefile.am where updated to check for systemd
 - --with-systemd (default=detect) was added to explicitely enable/disable systemd.
 - A new header file systemd.h was added
 - When it is detected that the daemon is started by systemd, the daemonize option will be ignored (service Type=simple)
 - Added sd_notify() at start-up and shut-down to notify systemd of status
 - Make use of the systemd watchdog (timeout = 30 secs), ping every 10secs by adding a timeout to select() in the main event loop.

TODO: Make template and installation for unit file.

Date:          Sat Jan 24 14:31:31 2026 +0100
Signed-off-by: Sietse van Zanen <uglymotha@wizdom.nu>

Changes to be committed:
	modified:   Makefile.am
	modified:   README
	modified:   configure.ac
	new file:   pure-ftpd.service
	modified:   src/Makefile.am
	modified:   src/ftpd.c
	new file:   src/systemd.h