### PR TITLE
Fix per-IP connection limit bypass due to inverted address family comparison

### DIFF
--- a/src/dynamic.c
+++ b/src/dynamic.c
@@ -42,7 +42,7 @@ static unsigned int iptrack_find_ip_or_shift
 
     do {
         if (iptrack_list[c].pid != (pid_t) 0 &&
-            STORAGE_FAMILY(iptrack_list[c].ip) != STORAGE_FAMILY(*ip)) {
+            STORAGE_FAMILY(iptrack_list[c].ip) == STORAGE_FAMILY(*ip)) {
             if (STORAGE_FAMILY(iptrack_list[c].ip) == AF_INET &&
                 STORAGE_SIN_ADDR_CONST(iptrack_list[c].ip) == STORAGE_SIN_ADDR_CONST(*ip)) {
                 return c;


### PR DESCRIPTION
### Bug

`iptrack_find_ip_or_shift()` in `src/dynamic.c` (line 45) uses `!=` to compare address families when searching for an existing IP tracking entry. This should be `==`.

The inverted comparison causes the function to never match an existing entry for the same IP address, because it only enters the address-comparison block when the families are *different*. It always falls through to the shift-and-evict path at the end of the array.

### Impact

When the `-C` (per-IP connection limit) flag is configured, an attacker can exceed the limit because every new connection from the same IP evicts an old entry instead of being counted against it.

### Evidence

The sibling function `iptrack_get()` (same file, line 76) performs the identical lookup and correctly uses `==`:

```c
// iptrack_find_ip_or_shift — BEFORE fix (line 45)
STORAGE_FAMILY(iptrack_list[c].ip) != STORAGE_FAMILY(*ip)  // BUG

// iptrack_get (line 76) — correct
STORAGE_FAMILY(iptrack_list[c].ip) == STORAGE_FAMILY(*ip)  // OK
```

### Fix

One-character change: `!=` → `==` on line 45 of `src/dynamic.c`.