### PR TITLE
Amend Fix: IPv4 octets bypass 0-255 validation

### DIFF
--- a/src/log_puredb.c
+++ b/src/log_puredb.c
@@ -156,6 +156,7 @@ static int access_ip_match(const struct sockaddr_storage * const sa,
         pattern = comapoint + 1;
     } while (*pattern != 0);
 
+ipcheck_nomatch:
     return 0;
 }
 


### PR DESCRIPTION
Fix contains a goto ipcheck_nomatch: But the label is not defined anywhere.
Define the label right before return 0.

Date:      Tue Apr 21 14:49:26 2026 +0200
Committer: Sietse van Zanen <uglymotha@wizdom.nu>
Changes to be committed:
	modified:   src/log_puredb.c