### PR TITLE
fix: escape quotes in pure-ftpwho -x XML output (CWE-116)

### DIFF
--- a/src/pure-ftpwho.c
+++ b/src/pure-ftpwho.c
@@ -248,6 +248,24 @@ static char *xml_escaped(const char *const s_) {
             *bufpnt++ = ';';
             left -= sizeof "&amp;" - (size_t) 1U;
             break;
+        case '\'':
+            if (left < sizeof "&apos;" - (size_t) 1U) {
+                *bufpnt = 0;
+                return buf;
+            }
+            *bufpnt++ = '&'; *bufpnt++ = 'a'; *bufpnt++ = 'p'; *bufpnt++ = 'o';
+            *bufpnt++ = 's'; *bufpnt++ = ';';
+            left -= sizeof "&apos;" - (size_t) 1U;
+            break;
+        case '"':
+            if (left < sizeof "&quot;" - (size_t) 1U) {
+                *bufpnt = 0;
+                return buf;
+            }
+            *bufpnt++ = '&'; *bufpnt++ = 'q'; *bufpnt++ = 'u'; *bufpnt++ = 'o';
+            *bufpnt++ = 't'; *bufpnt++ = ';';
+            left -= sizeof "&quot;" - (size_t) 1U;
+            break;
         default:
             *bufpnt++ = (char) *s;
             left--;


### PR DESCRIPTION
Escapes single and double quotes when emitting filename attributes in pure-ftpwho XML output.

- CWE-116: Improper Encoding or Escaping of Output
- Affected: Pure-FTPd <= 1.0.54 with --with-ftpwho